### PR TITLE
eahw-2235: Fix browser refresh causing undefined error

### DIFF
--- a/src/components/timecard/simple-time-period/SimpleTimePeriod.jsx
+++ b/src/components/timecard/simple-time-period/SimpleTimePeriod.jsx
@@ -93,7 +93,7 @@ const SimpleTimePeriod = ({ timeEntry, timeEntriesIndex, timePeriodTitle }) => {
                 Remove
                 <span className="govuk-visually-hidden">
                   {' '}
-                  {timePeriodTitle.toLowerCase()}
+                  {timePeriodTitle?.toLowerCase()}
                 </span>
               </Link>
             )}


### PR DESCRIPTION
Refreshing the browser when viewing a timecard and shift causes a blank screen and the below error. 

The fix is to add the optional chaining operator (?) so that toLowerCase() is not called on a null / empty object.

**Error**

TypeError: Cannot read properties of undefined (reading 'toLowerCase') at SimpleTimePeriod

![image](https://user-images.githubusercontent.com/104449079/193868865-25d4d3e0-b75c-4d6b-9e97-f439d08d6c50.png)
