### PR TITLE
App error on time entries request failure

### DIFF
--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -134,24 +134,30 @@ const updateTimeEntryContextData = async (
     .setFilters('ownerId==1', ...filterTimeEntriesOnDate(date))
     .getUrlSearchParams();
 
-  validateServiceErrors(setServiceError, async () => {
-    const timeEntriesResponse = await getTimeEntries(timeEntriesParams);
+  validateServiceErrors(
+    setServiceError,
+    async () => {
+      const timeEntriesResponse = await getTimeEntries(timeEntriesParams);
 
-    if (timeEntriesResponse.data.items?.length > 0) {
-      const existingTimeEntries = timeEntriesResponse.data.items.map(
-        (timeEntry) =>
-          new ContextTimeEntry(
-            timeEntry.id,
-            formatTime(timeEntry.actualStartTime),
-            timeEntry.actualEndTime ? formatTime(timeEntry.actualEndTime) : '',
-            timeEntry.timePeriodTypeId
-          )
-      );
-      setTimeEntries(existingTimeEntries);
-    } else {
-      setTimeEntries([]);
-    }
-  }, false);
+      if (timeEntriesResponse.data.items?.length > 0) {
+        const existingTimeEntries = timeEntriesResponse.data.items.map(
+          (timeEntry) =>
+            new ContextTimeEntry(
+              timeEntry.id,
+              formatTime(timeEntry.actualStartTime),
+              timeEntry.actualEndTime
+                ? formatTime(timeEntry.actualEndTime)
+                : '',
+              timeEntry.timePeriodTypeId
+            )
+        );
+        setTimeEntries(existingTimeEntries);
+      } else {
+        setTimeEntries([]);
+      }
+    },
+    false
+  );
 };
 
 const getTimePeriodTypesMap = (timePeriodTypes) => {

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -151,7 +151,7 @@ const updateTimeEntryContextData = async (
     } else {
       setTimeEntries([]);
     }
-  });
+  }, false);
 };
 
 const getTimePeriodTypesMap = (timePeriodTypes) => {

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -171,7 +171,7 @@ describe('Timecard', () => {
     await waitFor(() => {
       expect(defaultApplicationContext.setServiceError).toHaveBeenCalledWith({
         hasError: true,
-        recoverable: true,
+        recoverable: false,
       });
     });
   });


### PR DESCRIPTION
- set time entries retrival request to non recoverable error.
- update test.
Instead of being able to continue to use the timecard when an error occurs during the time entries retrieval, now we block the user from being able to continue.