### PR TITLE
Remove hint text

### DIFF
--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.jsx
@@ -6,9 +6,6 @@ const AddTimeCardPeriod = ({ timecardEmpty }) => {
   const addPeriodTitle = timecardEmpty
     ? 'Add time period'
     : 'Add another time period';
-  const addPeriodDescription = timecardEmpty
-    ? 'Use this to record a shift'
-    : 'Use this to record overtime or another shift';
 
   const { setNewTimeEntry } = useTimecardContext();
 
@@ -36,9 +33,6 @@ const AddTimeCardPeriod = ({ timecardEmpty }) => {
               </Link>
             </div>
           </div>
-          <p className="govuk-body-m govuk-secondary-text-colour">
-            {addPeriodDescription}
-          </p>
         </div>
       </div>
     </div>

--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
@@ -10,12 +10,8 @@ describe('AddTimeCardPeriod component', () => {
 
     await waitFor(() => {
       const addTimePeriodTitle = screen.queryByText('Add time period');
-      const addTimePeriodDescription = screen.queryByText(
-        'Use this to record a shift'
-      );
 
       expect(addTimePeriodTitle).toBeTruthy();
-      expect(addTimePeriodDescription).toBeTruthy();
     });
   });
 
@@ -24,9 +20,6 @@ describe('AddTimeCardPeriod component', () => {
 
     await waitFor(() => {
       const addTimePeriodTitle = screen.queryByText('Add another time period');
-      const addTimePeriodDescription = screen.queryByText(
-        'Use this to record overtime or another shift'
-      );
 
       expect(addTimePeriodTitle).toBeTruthy();
       expect(addTimePeriodDescription).toBeTruthy();

--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
@@ -22,7 +22,6 @@ describe('AddTimeCardPeriod component', () => {
       const addTimePeriodTitle = screen.queryByText('Add another time period');
 
       expect(addTimePeriodTitle).toBeTruthy();
-      expect(addTimePeriodDescription).toBeTruthy();
     });
   });
 

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -235,9 +235,6 @@ describe('Timecard', () => {
 
     expect(screen.getByText('08:00 to 16:00')).toBeInTheDocument();
     expect(screen.getByText('Add another time period')).toBeInTheDocument();
-    expect(
-      screen.getByText('Use this to record overtime or another shift')
-    ).toBeInTheDocument();
   });
 
   describe('navigation', () => {


### PR DESCRIPTION
Following on from a review it was decided the hint text should be removed from add a time entry. This PR removes that hint text. 

Jira Ticket: https://collaboration.homeoffice.gov.uk/jira/browse/EAHW-2244