### PR TITLE
EAHW-2243: Standardise "Add time period"

### DIFF
--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.jsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { addTimePeriodHeading } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 const AddTimeCardPeriod = () => {
-
   const { setNewTimeEntry } = useTimecardContext();
 
   const handleAddTimePeriod = (event) => {

--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.jsx
@@ -1,11 +1,8 @@
 import { useTimecardContext } from '../../../context/TimecardContext';
 import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { addTimePeriodHeading } from '../../../utils/time-entry-utils/timeEntryUtils';
 
-const AddTimeCardPeriod = ({ timecardEmpty }) => {
-  const addPeriodTitle = timecardEmpty
-    ? 'Add time period'
-    : 'Add another time period';
+const AddTimeCardPeriod = () => {
 
   const { setNewTimeEntry } = useTimecardContext();
 
@@ -20,7 +17,7 @@ const AddTimeCardPeriod = ({ timecardEmpty }) => {
         <div className="govuk-summary-list govuk-!-margin-bottom-0">
           <div className="govuk-summary-list__row govuk-summary-list__row--no-border">
             <p className="govuk-heading-s govuk-!-width-two-thirds">
-              {addPeriodTitle}
+              {addTimePeriodHeading}
             </p>
             <div className="govuk-summary-list__actions">
               <Link
@@ -40,7 +37,3 @@ const AddTimeCardPeriod = ({ timecardEmpty }) => {
 };
 
 export default AddTimeCardPeriod;
-
-AddTimeCardPeriod.propTypes = {
-  timecardEmpty: PropTypes.bool.isRequired,
-};

--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
@@ -3,13 +3,15 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { act } from 'react-test-renderer';
 
 import AddTimeCardPeriod from './AddTimeCardPeriod';
+import { addTimePeriodHeading } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 describe('AddTimeCardPeriod component', () => {
+
   it('should display an add timecard period component when timecard is empty', async () => {
     renderWithTimecardContext(<AddTimeCardPeriod timecardEmpty={true} />);
 
     await waitFor(() => {
-      const addTimePeriodTitle = screen.queryByText('Add time period');
+      const addTimePeriodTitle = screen.queryByText(addTimePeriodHeading);
 
       expect(addTimePeriodTitle).toBeTruthy();
     });
@@ -19,7 +21,7 @@ describe('AddTimeCardPeriod component', () => {
     renderWithTimecardContext(<AddTimeCardPeriod timecardEmpty={false} />);
 
     await waitFor(() => {
-      const addTimePeriodTitle = screen.queryByText('Add another time period');
+      const addTimePeriodTitle = screen.queryByText(addTimePeriodHeading);
 
       expect(addTimePeriodTitle).toBeTruthy();
     });

--- a/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
+++ b/src/components/timecard/add-timecard-period/AddTimeCardPeriod.spec.jsx
@@ -6,7 +6,6 @@ import AddTimeCardPeriod from './AddTimeCardPeriod';
 import { addTimePeriodHeading } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 describe('AddTimeCardPeriod component', () => {
-
   it('should display an add timecard period component when timecard is empty', async () => {
     renderWithTimecardContext(<AddTimeCardPeriod timecardEmpty={true} />);
 

--- a/src/components/timecard/select-timecard-period-type/SelectTimecardPeriodType.jsx
+++ b/src/components/timecard/select-timecard-period-type/SelectTimecardPeriodType.jsx
@@ -5,6 +5,7 @@ import { useTimecardContext } from '../../../context/TimecardContext';
 import Radios from '../../common/form/radios/Radios';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEntry';
+import { addTimePeriodHeading } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 const SelectTimecardPeriodType = () => {
   const {
@@ -49,7 +50,7 @@ const SelectTimecardPeriodType = () => {
       >
         <Radios
           name={radioName}
-          heading="Add a new time period"
+          heading={addTimePeriodHeading}
           headingSize="s"
           options={timePeriodTypeNames}
           errors={errors}

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -100,7 +100,7 @@ const Timecard = () => {
               {renderTimeEntry(timePeriodTypesMap, timeEntry, index)}
             </div>
           ))}
-          <AddTimeCardPeriod timecardEmpty={timeEntries.length === 0} />
+          <AddTimeCardPeriod/>
         </>
       )}
     </>

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -100,7 +100,7 @@ const Timecard = () => {
               {renderTimeEntry(timePeriodTypesMap, timeEntry, index)}
             </div>
           ))}
-          <AddTimeCardPeriod/>
+          <AddTimeCardPeriod />
         </>
       )}
     </>

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -7,7 +7,10 @@ import {
 import { shiftTimeEntry } from '../../../mocks/mockData';
 import Timecard from './Timecard';
 import { getTimeEntries } from '../../api/services/timecardService';
-import { addTimePeriodHeading, formatTime } from '../../utils/time-entry-utils/timeEntryUtils';
+import {
+  addTimePeriodHeading,
+  formatTime,
+} from '../../utils/time-entry-utils/timeEntryUtils';
 import { getApiResponseWithItems } from '../../../mocks/mock-utils';
 import { timeCardPeriodTypes } from '../../../mocks/mockData';
 

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -7,7 +7,7 @@ import {
 import { shiftTimeEntry } from '../../../mocks/mockData';
 import Timecard from './Timecard';
 import { getTimeEntries } from '../../api/services/timecardService';
-import { formatTime } from '../../utils/time-entry-utils/timeEntryUtils';
+import { addTimePeriodHeading, formatTime } from '../../utils/time-entry-utils/timeEntryUtils';
 import { getApiResponseWithItems } from '../../../mocks/mock-utils';
 import { timeCardPeriodTypes } from '../../../mocks/mockData';
 
@@ -212,7 +212,7 @@ describe('Timecard', () => {
       newTimeEntry: true,
     });
 
-    const heading = screen.getByText('Add a new time period');
+    const heading = screen.getByText(addTimePeriodHeading);
     expect(heading).toBeTruthy();
   });
 
@@ -234,7 +234,7 @@ describe('Timecard', () => {
     });
 
     expect(screen.getByText('08:00 to 16:00')).toBeInTheDocument();
-    expect(screen.getByText('Add another time period')).toBeInTheDocument();
+    expect(screen.getByText(addTimePeriodHeading)).toBeInTheDocument();
   });
 
   describe('navigation', () => {

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs';
 import { deepCloneJson } from '../common-utils/common-utils';
 
+export const addTimePeriodHeading = 'Add time period';
+
 export const getSingleTimeEntryResponseItem = (timeEntryResponseData) => {
   if (timeEntryResponseData.items && timeEntryResponseData.items.length > 0)
     return timeEntryResponseData.items[0];


### PR DESCRIPTION
- change add time period label variations to be consistent.
- update tests.

### New standardised headings/labels:

#### Select time period
<img width="788" alt="select time period" src="https://user-images.githubusercontent.com/108354209/199040409-bc60b06f-afee-4696-9abf-2b60b586e72a.PNG">

#### Add new time period
<img width="817" alt="add new time period" src="https://user-images.githubusercontent.com/108354209/199040489-3c911d97-98cc-4556-8dce-515d8ddcacdb.PNG">


See comment on ticket for original screens that needed fixing.
