### PR TITLE
Eahw 589 input day after start time

### DIFF
--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -15,7 +15,6 @@ const ValidatedTimeEntry = ({
   timeEntry,
   timeEntriesIndex,
 }) => {
-
   const { timeEntries, setTimeEntries } = useTimecardContext();
 
   const setFinishTimeText = () => {

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -69,7 +69,6 @@ export default ValidatedTimeEntry;
 ValidatedTimeEntry.propTypes = {
   name: PropTypes.string.isRequired,
   timeType: PropTypes.string.isRequired,
-  timeIndetifier: PropTypes.string.isRequired,
   errors: PropTypes.object.isRequired,
   defaultValue: PropTypes.string,
   register: PropTypes.any.isRequired,

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -18,13 +18,11 @@ const ValidatedTimeEntry = ({
   }, [formState]);
 
   const isFinishTimeNextDay = () => {
-    if (document.getElementById(`${name}-finish-time`)) {
-      var finishTimeValue = document.getElementById(
-        `${name}-finish-time`
-      ).value;
+    if (document.getElementById(`shift-finish-time`)) {
+      var finishTimeValue = document.getElementById(`shift-finish-time`).value;
     }
-    if (document.getElementById(`${name}-start-time`)) {
-      var startTimeValue = document.getElementById(`${name}-start-time`).value;
+    if (document.getElementById(`shift-start-time`)) {
+      var startTimeValue = document.getElementById(`shift-start-time`).value;
     }
     var answer = calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue);
 
@@ -71,6 +69,7 @@ export default ValidatedTimeEntry;
 ValidatedTimeEntry.propTypes = {
   name: PropTypes.string.isRequired,
   timeType: PropTypes.string.isRequired,
+  timeIndetifier: PropTypes.string.isRequired,
   errors: PropTypes.object.isRequired,
   defaultValue: PropTypes.string,
   register: PropTypes.any.isRequired,

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
 import { useTimecardContext } from '../../../../context/TimecardContext';
 import { deepCloneJson } from '../../../../utils/common-utils/common-utils';
 import { ContextTimeEntry } from '../../../../utils/time-entry-utils/ContextTimeEntry';
@@ -12,7 +11,6 @@ const ValidatedTimeEntry = ({
   defaultValue,
   register,
   isRequired,
-  formState,
   getValues,
   timeEntry,
   timeEntriesIndex,
@@ -20,10 +18,6 @@ const ValidatedTimeEntry = ({
   const errorMessage = `You must enter a ${timeType} in the HH:MM 24 hour clock format`;
 
   const { timeEntries, setTimeEntries } = useTimecardContext();
-
-  useEffect(() => {
-    setFinishTimeText();
-  }, [formState]);
 
   const setFinishTimeText = () => {
     const startTimeValue = getValues('shift-start-time');

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -29,7 +29,7 @@ const ValidatedTimeEntry = ({
     if (document.getElementById('end-next-day')) {
       if (answer >= 1) {
         document.getElementById('end-next-day').innerHTML =
-          'Shift ending on next day';
+          'Finishes on next day';
       } else {
         document.getElementById('end-next-day').innerHTML = '';
       }

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
+import { calculateFinishTimeOnNextDay } from '../../../../utils/time-entry-utils/timeEntryUtils';
 
 const ValidatedTimeEntry = ({
   name,
@@ -7,8 +9,34 @@ const ValidatedTimeEntry = ({
   defaultValue,
   register,
   isRequired,
+  formState,
 }) => {
   const errorMessage = `You must enter a ${timeType} in the HH:MM 24 hour clock format`;
+
+  useEffect(() => {
+    isFinishTimeNextDay();
+  }, [formState]);
+
+  const isFinishTimeNextDay = () => {
+    if (document.getElementById(`${name}-finish-time`)) {
+      var finishTimeValue = document.getElementById(
+        `${name}-finish-time`
+      ).value;
+    }
+    if (document.getElementById(`${name}-start-time`)) {
+      var startTimeValue = document.getElementById(`${name}-start-time`).value;
+    }
+    var answer = calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue);
+
+    if (document.getElementById('end-next-day')) {
+      if (answer >= 1) {
+        document.getElementById('end-next-day').innerHTML =
+          'Shift ending on next day';
+      } else {
+        document.getElementById('end-next-day').innerHTML = '';
+      }
+    }
+  };
   return (
     <input
       id={name}
@@ -24,6 +52,7 @@ const ValidatedTimeEntry = ({
       defaultValue={defaultValue}
       data-testid={name}
       {...register(name, {
+        onBlur: () => isFinishTimeNextDay(),
         required: {
           value: isRequired,
           message: errorMessage,
@@ -46,4 +75,6 @@ ValidatedTimeEntry.propTypes = {
   defaultValue: PropTypes.string,
   register: PropTypes.any.isRequired,
   isRequired: PropTypes.bool,
+  formState: PropTypes.any,
+  onBlur: PropTypes.bool,
 };

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -30,7 +30,7 @@ const ValidatedTimeEntry = ({
     const finishTimeValue = getValues('shift-finish-time');
     const newTimeEntries = deepCloneJson(timeEntries);
 
-    var answer = isFinishTimeOnNextDay(startTimeValue, finishTimeValue);
+    let answer = isFinishTimeOnNextDay(startTimeValue, finishTimeValue);
 
     newTimeEntries[timeEntriesIndex] =
       ContextTimeEntry.createFrom(timeEntry).setFinishNextDay(answer);

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -11,7 +11,7 @@ const ValidatedTimeEntry = ({
   defaultValue,
   register,
   isRequired,
-  getValues,
+  getFormValues,
   timeEntry,
   timeEntriesIndex,
 }) => {
@@ -20,11 +20,11 @@ const ValidatedTimeEntry = ({
   const { timeEntries, setTimeEntries } = useTimecardContext();
 
   const setFinishTimeText = () => {
-    const startTimeValue = getValues('shift-start-time');
-    const finishTimeValue = getValues('shift-finish-time');
+    const startTimeValue = getFormValues('shift-start-time');
+    const finishTimeValue = getFormValues('shift-finish-time');
     const newTimeEntries = deepCloneJson(timeEntries);
 
-    let answer = isFinishTimeOnNextDay(startTimeValue, finishTimeValue);
+    const answer = isFinishTimeOnNextDay(startTimeValue, finishTimeValue);
 
     newTimeEntries[timeEntriesIndex] =
       ContextTimeEntry.createFrom(timeEntry).setFinishNextDay(answer);
@@ -72,7 +72,7 @@ ValidatedTimeEntry.propTypes = {
   register: PropTypes.any.isRequired,
   isRequired: PropTypes.bool,
   formState: PropTypes.any,
-  getValues: PropTypes.func.isRequired,
+  getFormValues: PropTypes.func.isRequired,
   timeEntry: PropTypes.object.isRequired,
   timeEntriesIndex: PropTypes.number.isRequired,
 };

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -34,7 +34,7 @@ const ValidatedTimeEntry = ({
 
     newTimeEntries[timeEntriesIndex] =
       ContextTimeEntry.createFrom(timeEntry).setFinishNextDay(answer);
-    // setTimeEntries(newTimeEntries);
+    setTimeEntries(newTimeEntries);
   };
 
   return (

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -78,7 +78,7 @@ ValidatedTimeEntry.propTypes = {
   register: PropTypes.any.isRequired,
   isRequired: PropTypes.bool,
   formState: PropTypes.any,
-  getValues: PropTypes.func,
-  timeEntry: PropTypes.object,
+  getValues: PropTypes.func.isRequired,
+  timeEntry: PropTypes.object.isRequired,
   timeEntriesIndex: PropTypes.number.isRequired,
 };

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -1,5 +1,7 @@
 import { renderWithTimecardContext } from '../../../../test/helpers/TimecardContext';
 import { ContextTimeEntry } from '../../../../utils/time-entry-utils/ContextTimeEntry';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { act } from 'react-test-renderer';
 
 import ValidatedTimeEntry from './ValidatedTimeEntry';
 
@@ -36,5 +38,31 @@ describe('ValidatedTimeEntry', () => {
     );
 
     expect(component).toBeTruthy();
+  });
+
+  it('should call onblur method', async () => {
+    const setFinishTimeTextSpy = jest.fn();
+
+    const component = renderWithTimecardContext(
+      <ValidatedTimeEntry
+        name="shift-finish-time"
+        timeType="finish time"
+        errors={{}}
+        register={setFinishTimeTextSpy}
+        getValues={jest.fn()}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
+      />
+    );
+
+    act(() => {
+      const someElement =
+        component.container.querySelector('#shift-finish-time');
+      fireEvent.blur(someElement);
+    });
+
+    await waitFor(() => {
+      expect(setFinishTimeTextSpy).toBeCalledTimes(1);
+    });
   });
 });

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -3,7 +3,20 @@ import { render } from '@testing-library/react';
 import ValidatedTimeEntry from './ValidatedTimeEntry';
 
 describe('ValidatedTimeEntry', () => {
-  it('should render correctly', () => {
+  it('should render start time correctly', () => {
+    const component = render(
+      <ValidatedTimeEntry
+        name="shift-start-time"
+        timeType="start time"
+        errors={{}}
+        register={jest.fn()}
+      />
+    );
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should render finish time correctly', () => {
     const component = render(
       <ValidatedTimeEntry
         name="shift-finish-time"

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -1,15 +1,21 @@
-import { render } from '@testing-library/react';
+import { renderWithTimecardContext } from '../../../../test/helpers/TimecardContext';
+import { ContextTimeEntry } from '../../../../utils/time-entry-utils/ContextTimeEntry';
 
 import ValidatedTimeEntry from './ValidatedTimeEntry';
 
 describe('ValidatedTimeEntry', () => {
+  const timeEntry = new ContextTimeEntry();
+
   it('should render start time correctly', () => {
-    const component = render(
+    const component = renderWithTimecardContext(
       <ValidatedTimeEntry
         name="shift-start-time"
         timeType="start time"
         errors={{}}
         register={jest.fn()}
+        getValues={jest.fn()}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
       />
     );
 
@@ -17,12 +23,15 @@ describe('ValidatedTimeEntry', () => {
   });
 
   it('should render finish time correctly', () => {
-    const component = render(
+    const component = renderWithTimecardContext(
       <ValidatedTimeEntry
         name="shift-finish-time"
         timeType="finish time"
         errors={{}}
         register={jest.fn()}
+        getValues={jest.fn()}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
       />
     );
 

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -6,8 +6,8 @@ describe('ValidatedTimeEntry', () => {
   it('should render correctly', () => {
     const component = render(
       <ValidatedTimeEntry
-        name="start-time"
-        timeType="start time"
+        name="shift-finish-time"
+        timeType="finish time"
         errors={{}}
         register={jest.fn()}
       />

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -94,14 +94,11 @@ const EditShiftHours = ({
     );
 
     const endTime = formData[`${inputName}-finish-time`] || null;
-    let actualEndDate = formatDate(timecardDate);
+    let actualEndDateTime = '';
     if (endTime) {
-      actualEndDate = setFinishTimeDate(actualStartDate);
+      const actualEndDate = setFinishTimeDate(actualStartDate);
+      actualEndDateTime = formatDateTimeISO(actualEndDate + ' ' + endTime);
     }
-
-    const actualEndDateTime = endTime
-      ? formatDateTimeISO(actualEndDate + ' ' + endTime)
-      : '';
 
     const timecardPayload = {
       ownerId: userId,

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -12,6 +12,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import {
+  calculateFinishTimeOnNextDay,
   formatDate,
   formatDateTimeISO,
   formatTime,
@@ -50,6 +51,18 @@ const EditShiftHours = ({
     setSummaryErrors(errorFields);
   };
 
+  const isFinishTimeNextDay = (
+    actualStartTime,
+    actualEndTime,
+    actualStartDate
+  ) => {
+    if (calculateFinishTimeOnNextDay(actualStartTime, actualEndTime) >= 1) {
+      return formatDate(dayjs(actualStartDate).add(1, 'day'));
+    } else {
+      return actualStartDate;
+    }
+  };
+
   const handleServerValidationErrors = (error) => {
     const summaryErrors = {};
     let errorsHandled = true;
@@ -85,8 +98,18 @@ const EditShiftHours = ({
     );
 
     const endTime = formData[`${inputName}-finish-time`] || null;
+    var actualEndDate = formatDate(timecardDate);
+
+    if (endTime) {
+      actualEndDate = isFinishTimeNextDay(
+        actualStartTime,
+        endTime,
+        actualStartDate
+      );
+    }
+
     const actualEndDateTime = endTime
-      ? formatDateTimeISO(actualStartDate + ' ' + endTime)
+      ? formatDateTimeISO(actualEndDate + ' ' + endTime)
       : '';
 
     const timecardPayload = {

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -30,7 +30,7 @@ const EditShiftHours = ({
     handleSubmit,
     formState: { errors },
     formState,
-    getFormValues,
+    getValues,
   } = useForm({
     reValidateMode: 'onSubmit',
     shouldFocusError: false,
@@ -51,7 +51,7 @@ const EditShiftHours = ({
     setSummaryErrors(errorFields);
   };
 
-  const setFinishTimeDate = (actualStartDate) => {
+  const getFinishTimeDate = (actualStartDate) => {
     if (timeEntry.finishNextDay) {
       return formatDate(dayjs(actualStartDate).add(1, 'day'));
     } else {
@@ -93,7 +93,7 @@ const EditShiftHours = ({
     const endTime = formData[`${inputName}-finish-time`] || null;
     let actualEndDateTime = '';
     if (endTime) {
-      const actualEndDate = setFinishTimeDate(actualStartDate);
+      const actualEndDate = getFinishTimeDate(actualStartDate);
       actualEndDateTime = formatDateTimeISO(actualEndDate + ' ' + endTime);
     }
 
@@ -152,7 +152,7 @@ const EditShiftHours = ({
           errors={Object.keys(errors).length > 0 ? errors : summaryErrors}
           register={register}
           formState={formState}
-          getFormValues={getFormValues}
+          getFormValues={getValues}
           timeEntry={timeEntry}
           startTimeValue={
             timeEntry.startTime ? formatTime(timeEntry.startTime) : ''

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -30,7 +30,7 @@ const EditShiftHours = ({
     handleSubmit,
     formState: { errors },
     formState,
-    getValues,
+    getFormValues,
   } = useForm({
     reValidateMode: 'onSubmit',
     shouldFocusError: false,
@@ -152,7 +152,7 @@ const EditShiftHours = ({
           errors={Object.keys(errors).length > 0 ? errors : summaryErrors}
           register={register}
           formState={formState}
-          getValues={getValues}
+          getFormValues={getFormValues}
           timeEntry={timeEntry}
           startTimeValue={
             timeEntry.startTime ? formatTime(timeEntry.startTime) : ''

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -15,11 +15,10 @@ import {
   shiftTimeEntry,
   shiftTimeEntryWithoutFinishTime,
 } from '../../../../mocks/mockData';
-import { deepCloneJson } from '../../../utils/common-utils/common-utils';
-import { formatDateTimeISO } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 const newTimeEntry = {
   timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+  finishNextDay: false,
 };
 
 const timecardService = require('../../../api/services/timecardService');
@@ -33,16 +32,15 @@ describe('EditShiftHours', () => {
     const expectedActualStartTime = `${timecardDate}T${inputtedStartTime}:00+00:00`;
 
     it('should call createTimeEntry when pressing save with no existing time entry', async () => {
-      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
-      mockTimecardContext.timecardDate = timecardDate;
+      defaultTimecardContext.timecardDate = timecardDate;
 
       renderWithTimecardContext(
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
-          index={0}
+          timeEntriesIndex={0}
         />,
-        mockTimecardContext
+        defaultTimecardContext
       );
 
       act(() => {
@@ -81,16 +79,15 @@ describe('EditShiftHours', () => {
         endTime: '05:00',
       };
 
-      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
-      mockTimecardContext.timecardDate = timecardDate;
+      defaultTimecardContext.timecardDate = timecardDate;
 
       renderWithTimecardContext(
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={existingTimeEntry}
-          index={0}
+          timeEntriesIndex={0}
         />,
-        mockTimecardContext
+        defaultTimecardContext
       );
 
       act(() => {
@@ -138,7 +135,7 @@ describe('EditShiftHours', () => {
           <EditShiftHours
             setShowEditShiftHours={jest.fn()}
             timeEntry={newTimeEntry}
-            index={0}
+            timeEntriesIndex={0}
           />,
           defaultTimecardContext,
           defaultApplicationContext
@@ -175,7 +172,7 @@ describe('EditShiftHours', () => {
           <EditShiftHours
             setShowEditShiftHours={jest.fn()}
             timeEntry={newTimeEntry}
-            index={0}
+            timeEntriesIndex={0}
           />,
           defaultTimecardContext,
           defaultApplicationContext
@@ -208,17 +205,12 @@ describe('EditShiftHours', () => {
       data: getApiResponseWithItems(shiftTimeEntry),
     });
 
-    const mockTimecardContext = deepCloneJson(defaultTimecardContext);
-    mockTimecardContext.timecardDate = '2022-11-11';
-    mockTimecardContext.setTimeEntries = jest.fn();
-
     renderWithTimecardContext(
       <EditShiftHours
         setShowEditShiftHours={jest.fn()}
         timeEntry={newTimeEntry}
         timeEntriesIndex={0}
-      />,
-      mockTimecardContext
+      />
     );
 
     const startTimeInput = screen.getByTestId('shift-start-time');
@@ -233,12 +225,13 @@ describe('EditShiftHours', () => {
     });
 
     await waitFor(() => {
-      expect(mockTimecardContext.setTimeEntries).toHaveBeenCalledWith([
+      expect(defaultTimecardContext.setTimeEntries).toHaveBeenCalledWith([
         {
-          startTime: '12:00',
-          finishTime: '22:00',
+          startTime: shiftTimeEntry.actualStartTime,
+          finishTime: shiftTimeEntry.actualEndTime,
           timeEntryId: 'c0a80040-82cf-1986-8182-cfedbbd50003',
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          finishNextDay: false,
         },
       ]);
     });
@@ -249,16 +242,12 @@ describe('EditShiftHours', () => {
       data: getApiResponseWithItems(shiftTimeEntryWithoutFinishTime),
     });
 
-    const mockTimecardContext = deepCloneJson(defaultTimecardContext);
-    mockTimecardContext.setTimeEntries = jest.fn();
-
     renderWithTimecardContext(
       <EditShiftHours
         setShowEditShiftHours={jest.fn()}
         timeEntry={newTimeEntry}
         timeEntriesIndex={0}
-      />,
-      mockTimecardContext
+      />
     );
 
     const startTimeInput = screen.getByTestId('shift-start-time');
@@ -270,12 +259,13 @@ describe('EditShiftHours', () => {
     });
 
     await waitFor(() => {
-      expect(mockTimecardContext.setTimeEntries).toHaveBeenCalledWith([
+      expect(defaultTimecardContext.setTimeEntries).toHaveBeenCalledWith([
         {
-          startTime: '12:00',
+          startTime: shiftTimeEntryWithoutFinishTime.actualStartTime,
           finishTime: '',
           timeEntryId: 'c0a80040-82cf-1986-8182-cfedbbd50004',
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          finishNextDay: false,
         },
       ]);
     });
@@ -286,7 +276,7 @@ describe('EditShiftHours', () => {
       <EditShiftHours
         setShowEditShiftHours={jest.fn()}
         timeEntry={newTimeEntry}
-        index={0}
+        timeEntriesIndex={0}
       />
     );
 
@@ -310,7 +300,7 @@ describe('EditShiftHours', () => {
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
-          index={0}
+          timeEntriesIndex={0}
         />
       );
 
@@ -338,7 +328,7 @@ describe('EditShiftHours', () => {
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
-          index={0}
+          timeEntriesIndex={0}
         />
       );
 
@@ -366,7 +356,7 @@ describe('EditShiftHours', () => {
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
-          index={0}
+          timeEntriesIndex={0}
         />
       );
 
@@ -394,7 +384,7 @@ describe('EditShiftHours', () => {
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
-          index={0}
+          timeEntriesIndex={0}
         />
       );
 
@@ -428,16 +418,14 @@ describe('EditShiftHours', () => {
         };
       });
 
-      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
-      mockTimecardContext.setSummaryErrors = jest.fn();
-
+      defaultTimecardContext.setSummaryErrors = jest.fn();
       renderWithTimecardContext(
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
           timeEntriesIndex={0}
         />,
-        mockTimecardContext
+        defaultTimecardContext
       );
 
       const startTimeInput = screen.getByTestId('shift-start-time');
@@ -452,7 +440,7 @@ describe('EditShiftHours', () => {
       });
 
       await waitFor(() => {
-        expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
+        expect(defaultTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
           'shift-start-time': {
             message: 'Time periods must not overlap with another time period',
           },
@@ -472,16 +460,14 @@ describe('EditShiftHours', () => {
         };
       });
 
-      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
-      mockTimecardContext.setSummaryErrors = jest.fn();
-
+      defaultTimecardContext.setSummaryErrors = jest.fn();
       renderWithTimecardContext(
         <EditShiftHours
           setShowEditShiftHours={jest.fn()}
           timeEntry={newTimeEntry}
           timeEntriesIndex={0}
         />,
-        mockTimecardContext
+        defaultTimecardContext
       );
 
       const startTimeInput = screen.getByTestId('shift-start-time');
@@ -496,7 +482,7 @@ describe('EditShiftHours', () => {
       });
 
       await waitFor(() => {
-        expect(mockTimecardContext.setSummaryErrors).not.toHaveBeenCalled();
+        expect(defaultTimecardContext.setSummaryErrors).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -72,7 +72,7 @@ describe('EditShiftHours', () => {
 
     it('should call updateTimeEntry when pressing save when there is an existing time entry', async () => {
       const timeEntryId = '1';
-      const inputtedEndTime = '06:00';
+      const inputtedEndTime = '10:00';
 
       const existingTimeEntry = {
         ...newTimeEntry,

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -15,7 +15,6 @@ import {
   shiftTimeEntry,
   shiftTimeEntryWithoutFinishTime,
 } from '../../../../mocks/mockData';
-import { deepCloneJson } from '../../../utils/common-utils/common-utils';
 import { expectNeverToHappen } from '../../../test/helpers/Helpers';
 
 const newTimeEntry = {

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -70,7 +70,7 @@ describe('EditShiftHours', () => {
 
     it('should call updateTimeEntry when pressing save when there is an existing time entry', async () => {
       const timeEntryId = '1';
-      const inputtedEndTime = '10:00';
+      const inputtedEndTime = '06:00';
 
       const existingTimeEntry = {
         ...newTimeEntry,

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -1,6 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { act } from 'react-test-renderer';
-
 import {
   defaultApplicationContext,
   defaultTimecardContext,
@@ -17,6 +16,7 @@ import {
   shiftTimeEntryWithoutFinishTime,
 } from '../../../../mocks/mockData';
 import { deepCloneJson } from '../../../utils/common-utils/common-utils';
+import { formatDateTimeISO } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 const newTimeEntry = {
   timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -209,6 +209,7 @@ describe('EditShiftHours', () => {
     });
 
     const mockTimecardContext = deepCloneJson(defaultTimecardContext);
+    mockTimecardContext.timecardDate = '2022-11-11';
     mockTimecardContext.setTimeEntries = jest.fn();
 
     renderWithTimecardContext(

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -1,15 +1,19 @@
 import { PropTypes } from 'prop-types';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import dayjs from 'dayjs';
 import EditShiftHours from '../edit-shift-hours/EditShiftHours';
 import { deleteTimeEntry } from '../../../api/services/timecardService';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import { useTimecardContext } from '../../../context/TimecardContext';
-import { removeTimecardContextEntry } from '../../../utils/time-entry-utils/timeEntryUtils';
+import {
+  calculateFinishTimeOnNextDay,
+  removeTimecardContextEntry,
+} from '../../../utils/time-entry-utils/timeEntryUtils';
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 
-const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
+const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
   const toggleEditShiftHours = (event) => {
     event.preventDefault();
     setShowEditShiftHours(!showEditShiftHours);
@@ -33,6 +37,14 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
       await deleteTimeEntry(timeEntry.timeEntryId, params);
       removeTimecardContextEntry(timeEntries, setTimeEntries, timeEntriesIndex);
     });
+  };
+
+  const isFinishTimeNextDay = (startTimeValue, finishTimeValue) => {
+    if (calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue) >= 1) {
+      return dayjs(date).add(1, 'day').format('DD MMMM');
+    } else {
+      return dayjs(date).format('DD MMMM');
+    }
   };
 
   return (
@@ -70,7 +82,10 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
               timeEntryExists &&
               `${timeEntry.startTime} to ${
                 timeEntry.finishTime ? timeEntry.finishTime : '-'
-              }`}
+              } on ${isFinishTimeNextDay(
+                timeEntry.startTime,
+                timeEntry.finishTime
+              )}`}
           </dd>
           <dd className="govuk-summary-list__actions">
             {timeEntryExists && (
@@ -132,4 +147,5 @@ export default EditShiftTimecard;
 EditShiftTimecard.propTypes = {
   timeEntry: PropTypes.object,
   timeEntriesIndex: PropTypes.number,
+  date: PropTypes.string.isRequired,
 };

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -1,19 +1,15 @@
 import { PropTypes } from 'prop-types';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import dayjs from 'dayjs';
 import EditShiftHours from '../edit-shift-hours/EditShiftHours';
 import { deleteTimeEntry } from '../../../api/services/timecardService';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import { useTimecardContext } from '../../../context/TimecardContext';
-import {
-  calculateFinishTimeOnNextDay,
-  removeTimecardContextEntry,
-} from '../../../utils/time-entry-utils/timeEntryUtils';
+import { removeTimecardContextEntry } from '../../../utils/time-entry-utils/timeEntryUtils';
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 
-const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
+const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
   const toggleEditShiftHours = (event) => {
     event.preventDefault();
     setShowEditShiftHours(!showEditShiftHours);
@@ -39,13 +35,13 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
     });
   };
 
-  const isFinishTimeNextDay = (startTimeValue, finishTimeValue) => {
-    if (calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue) >= 1) {
-      return `on ${dayjs(date).add(1, 'day').format('DD MMMM')}`;
-    } else {
-      return '';
-    }
-  };
+  // const isFinishTimeNextDay = (startTimeValue, finishTimeValue) => {
+  //   if (calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue) >= 1) {
+  //     return `on ${dayjs(date).add(1, 'day').format('DD MMMM')}`;
+  //   } else {
+  //     return '';
+  //   }
+  // };
 
   return (
     <div className="grey-border">
@@ -88,10 +84,7 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
               timeEntryExists &&
               `${timeEntry.startTime} to ${
                 timeEntry.finishTime ? timeEntry.finishTime : '-'
-              } \n ${isFinishTimeNextDay(
-                timeEntry.startTime,
-                timeEntry.finishTime
-              )}`}
+              } on ${timeEntry.finishDate}`}
           </dd>
           <dd className="govuk-summary-list__actions">
             {timeEntryExists && (
@@ -153,5 +146,4 @@ export default EditShiftTimecard;
 EditShiftTimecard.propTypes = {
   timeEntry: PropTypes.object,
   timeEntriesIndex: PropTypes.number,
-  date: PropTypes.string.isRequired,
 };

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -5,7 +5,11 @@ import EditShiftHours from '../edit-shift-hours/EditShiftHours';
 import { deleteTimeEntry } from '../../../api/services/timecardService';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import { useTimecardContext } from '../../../context/TimecardContext';
-import { removeTimecardContextEntry } from '../../../utils/time-entry-utils/timeEntryUtils';
+import {
+  formatDateNoYear,
+  formatTime,
+  removeTimecardContextEntry,
+} from '../../../utils/time-entry-utils/timeEntryUtils';
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 
@@ -34,14 +38,6 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
       removeTimecardContextEntry(timeEntries, setTimeEntries, timeEntriesIndex);
     });
   };
-
-  // const isFinishTimeNextDay = (startTimeValue, finishTimeValue) => {
-  //   if (calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue) >= 1) {
-  //     return `on ${dayjs(date).add(1, 'day').format('DD MMMM')}`;
-  //   } else {
-  //     return '';
-  //   }
-  // };
 
   return (
     <div className="grey-border">
@@ -82,9 +78,13 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
           >
             {!showEditShiftHours &&
               timeEntryExists &&
-              `${timeEntry.startTime} to ${
-                timeEntry.finishTime ? timeEntry.finishTime : '-'
-              } on ${timeEntry.finishDate}`}
+              `${formatTime(timeEntry.startTime)} to ${
+                timeEntry.finishTime ? formatTime(timeEntry.finishTime) : '-'
+              } on ${
+                timeEntry.finishNextDay
+                  ? formatDateNoYear(timeEntry.finishTime)
+                  : ''
+              }`}
           </dd>
           <dd className="govuk-summary-list__actions">
             {timeEntryExists && (

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -41,9 +41,9 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
 
   const isFinishTimeNextDay = (startTimeValue, finishTimeValue) => {
     if (calculateFinishTimeOnNextDay(startTimeValue, finishTimeValue) >= 1) {
-      return dayjs(date).add(1, 'day').format('DD MMMM');
+      return `on ${dayjs(date).add(1, 'day').format('DD MMMM')}`;
     } else {
-      return dayjs(date).format('DD MMMM');
+      return '';
     }
   };
 
@@ -58,7 +58,7 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
             Shift
           </dt>
           <dd className="govuk-summary-list__value"></dd>
-          <dd className="govuk-summary-list__actions" style={{ width: '10%' }}>
+          <dd className="govuk-summary-list__actions" style={{ width: '43%' }}>
             {timeEntryExists && (
               <Link
                 onClick={handleClickRemoveShiftButton}
@@ -81,14 +81,14 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
             Hours
           </dt>
           <dd
-            className="govuk-summary-list__value"
-            style={{ whiteSpace: 'pre-line', textAlign: 'center' }}
+            className="govuk-summary-list__value govuk-!-width-full"
+            style={{ whiteSpace: 'nowrap' }}
           >
             {!showEditShiftHours &&
               timeEntryExists &&
               `${timeEntry.startTime} to ${
                 timeEntry.finishTime ? timeEntry.finishTime : '-'
-              } \n on ${isFinishTimeNextDay(
+              } \n ${isFinishTimeNextDay(
                 timeEntry.startTime,
                 timeEntry.finishTime
               )}`}

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -73,16 +73,22 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex, date }) => {
         <div className="govuk-summary-list__row govuk-summary-list__row--no-border">
           <dt
             className="govuk-summary-list__key"
-            style={{ paddingBottom: '20px', paddingTop: '20px' }}
+            style={{
+              paddingBottom: '20px',
+              paddingTop: '20px',
+            }}
           >
             Hours
           </dt>
-          <dd className="govuk-summary-list__value">
+          <dd
+            className="govuk-summary-list__value"
+            style={{ whiteSpace: 'pre-line', textAlign: 'center' }}
+          >
             {!showEditShiftHours &&
               timeEntryExists &&
               `${timeEntry.startTime} to ${
                 timeEntry.finishTime ? timeEntry.finishTime : '-'
-              } on ${isFinishTimeNextDay(
+              } \n on ${isFinishTimeNextDay(
                 timeEntry.startTime,
                 timeEntry.finishTime
               )}`}

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -80,9 +80,9 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
               timeEntryExists &&
               `${formatTime(timeEntry.startTime)} to ${
                 timeEntry.finishTime ? formatTime(timeEntry.finishTime) : '-'
-              } on ${
+              } ${
                 timeEntry.finishNextDay
-                  ? formatDateNoYear(timeEntry.finishTime)
+                  ? ` on ${formatDateNoYear(timeEntry.finishTime)}`
                   : ''
               }`}
           </dd>

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -20,8 +20,8 @@ let existingTimeEntry;
 beforeEach(() => {
   existingTimeEntry = {
     timeEntryId: '00000000-0000-0000-0000-000000000001',
-    startTime: '08:00',
-    finishTime: '16:00',
+    startTime: '2022-11-01T08:00:00Z',
+    finishTime: '2022-11-01T16:00:00Z',
     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
   };
 });

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -288,6 +288,7 @@ describe('EditShiftTimecard', () => {
 
       await waitFor(() => {
         expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
+        expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
       });
     });
 
@@ -305,6 +306,7 @@ describe('EditShiftTimecard', () => {
 
       await waitFor(() => {
         expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
+        expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
       });
     });
   });

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -246,7 +246,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.getByText('08:00 to - on 31 October')).toBeTruthy();
+      expect(screen.getByText('08:00 to -')).toBeTruthy();
     });
 
     it('should display start and finish time on timecard when both times have been entered', async () => {
@@ -254,7 +254,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.getByText('08:00 to 16:00 on 31 October')).toBeTruthy();
+      expect(screen.getByText('08:00 to 16:00')).toBeTruthy();
     });
 
     it('should not display start and finish time on timecard when nothing has been entered', async () => {
@@ -270,7 +270,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.getByText('08:00 to 16:00 on 31 October')).toBeTruthy();
+      expect(screen.getByText('08:00 to 16:00')).toBeTruthy();
 
       act(() => {
         const changeButton = screen.getByTestId('hours-change-button');

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -262,10 +262,18 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={newTimeEntry} timeEntriesIndex={0} />
       );
 
+      expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
+    });
+
+    it('should not display start and finish time with date on timecard when nothing has been entered', async () => {
+      renderWithTimecardContext(
+        <EditShiftTimecard timeEntry={newTimeEntry} timeEntriesIndex={0} />
+      );
+
       expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
     });
 
-    it('should not display start and finish time on timecard when edit hours toggle is open', async () => {
+    it('should not display start, finish time on timecard when edit hours toggle is open', async () => {
       renderWithTimecardContext(
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
@@ -278,7 +286,24 @@ describe('EditShiftTimecard', () => {
       });
 
       await waitFor(() => {
-        expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
+        expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
+      });
+    });
+
+    it('should not display start, finish time and date on timecard when edit hours toggle is open', async () => {
+      renderWithTimecardContext(
+        <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
+      );
+
+      expect(screen.getByText(`08:00 to 16:00`)).toBeTruthy();
+
+      act(() => {
+        const changeButton = screen.getByTestId('hours-change-button');
+        fireEvent.click(changeButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
       });
     });
   });

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -270,6 +270,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={newTimeEntry} timeEntriesIndex={0} />
       );
 
+      expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
       expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
     });
 

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -246,7 +246,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.getByText('08:00 to -')).toBeTruthy();
+      expect(screen.getByText('08:00 to - on 31 October')).toBeTruthy();
     });
 
     it('should display start and finish time on timecard when both times have been entered', async () => {
@@ -254,7 +254,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.getByText('08:00 to 16:00')).toBeTruthy();
+      expect(screen.getByText('08:00 to 16:00 on 31 October')).toBeTruthy();
     });
 
     it('should not display start and finish time on timecard when nothing has been entered', async () => {
@@ -262,7 +262,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={newTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
+      expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
     });
 
     it('should not display start and finish time on timecard when edit hours toggle is open', async () => {
@@ -270,7 +270,7 @@ describe('EditShiftTimecard', () => {
         <EditShiftTimecard timeEntry={existingTimeEntry} timeEntriesIndex={0} />
       );
 
-      expect(screen.getByText('08:00 to 16:00')).toBeTruthy();
+      expect(screen.getByText('08:00 to 16:00 on 31 October')).toBeTruthy();
 
       act(() => {
         const changeButton = screen.getByTestId('hours-change-button');
@@ -278,7 +278,7 @@ describe('EditShiftTimecard', () => {
       });
 
       await waitFor(() => {
-        expect(screen.queryByText('08:00 to 16:00')).toBeFalsy();
+        expect(screen.queryByText('08:00 to 16:00 on 31 October')).toBeFalsy();
       });
     });
   });

--- a/src/components/timecard/simple-time-period/SimpleTimePeriod.spec.jsx
+++ b/src/components/timecard/simple-time-period/SimpleTimePeriod.spec.jsx
@@ -161,6 +161,7 @@ describe('SimpleTimePeriod', () => {
             startTime: midnight,
             finishTime: midnight,
             timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
+            finishNextDay: false,
           },
         ]);
       });

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -96,6 +96,10 @@ const StartFinishTimeInput = ({
             />
           </div>
         </div>
+        <p
+          id="end-next-day"
+          className="govuk-hint govuk-grid-column-one-third govuk-!-padding-top-8 govuk-!-padding-right-0 govuk-!-padding-left-0"
+        ></p>
       </div>
     </div>
   );

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -8,6 +8,9 @@ const StartFinishTimeInput = ({
   errors,
   startTimeValue,
   finishTimeValue,
+  getValues,
+  timeEntry,
+  timeEntriesIndex,
   register,
   formState,
 }) => {
@@ -69,8 +72,9 @@ const StartFinishTimeInput = ({
             defaultValue={startTimeValue}
             register={register}
             isRequired={true}
-            autoComplete="off"
-            type="text"
+            getValues={getValues}
+            timeEntry={timeEntry}
+            timeEntriesIndex={timeEntriesIndex}
           />
         </div>
 
@@ -91,15 +95,18 @@ const StartFinishTimeInput = ({
               errors={errors}
               defaultValue={finishTimeValue}
               register={register}
-              autoComplete="off"
-              type="text"
+              getValues={getValues}
+              timeEntry={timeEntry}
+              timeEntriesIndex={timeEntriesIndex}
             />
           </div>
         </div>
         <p
           id="end-next-day"
           className="govuk-hint govuk-grid-column-one-third govuk-!-padding-top-8 govuk-!-padding-right-0 govuk-!-padding-left-0"
-        ></p>
+        >
+          {timeEntry.finishNextDay ? 'Finishes next day' : ''}
+        </p>
       </div>
     </div>
   );
@@ -112,6 +119,9 @@ StartFinishTimeInput.propTypes = {
   errors: PropTypes.any.isRequired,
   startTimeValue: PropTypes.string,
   finishTimeValue: PropTypes.string,
+  getValues: PropTypes.func.isRequired,
+  timeEntry: PropTypes.object.isRequired,
+  timeEntriesIndex: PropTypes.number.isRequired,
   register: PropTypes.any.isRequired,
   formState: PropTypes.any,
 };

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -8,7 +8,7 @@ const StartFinishTimeInput = ({
   errors,
   startTimeValue,
   finishTimeValue,
-  getValues,
+  getFormValues,
   timeEntry,
   timeEntriesIndex,
   register,
@@ -72,7 +72,7 @@ const StartFinishTimeInput = ({
             defaultValue={startTimeValue}
             register={register}
             isRequired={true}
-            getValues={getValues}
+            getFormValues={getFormValues}
             timeEntry={timeEntry}
             timeEntriesIndex={timeEntriesIndex}
           />
@@ -95,7 +95,7 @@ const StartFinishTimeInput = ({
               errors={errors}
               defaultValue={finishTimeValue}
               register={register}
-              getValues={getValues}
+              getFormValues={getFormValues}
               timeEntry={timeEntry}
               timeEntriesIndex={timeEntriesIndex}
             />
@@ -119,7 +119,7 @@ StartFinishTimeInput.propTypes = {
   errors: PropTypes.any.isRequired,
   startTimeValue: PropTypes.string,
   finishTimeValue: PropTypes.string,
-  getValues: PropTypes.func.isRequired,
+  getFormValues: PropTypes.func.isRequired,
   timeEntry: PropTypes.object.isRequired,
   timeEntriesIndex: PropTypes.number.isRequired,
   register: PropTypes.any.isRequired,

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
@@ -1,15 +1,21 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
+import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEntry';
 import StartFinishTimeInput from './StartFinishTimeInput';
 
 const mockRegister = jest.fn();
+const timeEntry = new ContextTimeEntry();
 
 describe('StartFinishTimeInput', () => {
   it('should display titles for each input box', () => {
-    render(
+    renderWithTimecardContext(
       <StartFinishTimeInput
         name={'shift'}
         errors={{}}
         register={mockRegister}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
+        getValues={jest.fn()}
       />
     );
 
@@ -21,11 +27,14 @@ describe('StartFinishTimeInput', () => {
   });
 
   it('should display hints for each input box', () => {
-    render(
+    renderWithTimecardContext(
       <StartFinishTimeInput
         name={'shift'}
         errors={{}}
         register={mockRegister}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
+        getValues={jest.fn()}
       />
     );
 
@@ -37,11 +46,14 @@ describe('StartFinishTimeInput', () => {
   });
 
   it('should update the input value on change', () => {
-    render(
+    renderWithTimecardContext(
       <StartFinishTimeInput
         name={'shift'}
         errors={{}}
         register={mockRegister}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
+        getValues={jest.fn()}
       />
     );
 
@@ -56,13 +68,16 @@ describe('StartFinishTimeInput', () => {
   });
 
   it('should pre-fill the inputs if values are passed in', () => {
-    render(
+    renderWithTimecardContext(
       <StartFinishTimeInput
         name={'shift'}
         startTimeValue="07:00"
         finishTimeValue="17:00"
         errors={{}}
         register={mockRegister}
+        timeEntry={timeEntry}
+        timeEntriesIndex={0}
+        getValues={jest.fn()}
       />
     );
 
@@ -78,7 +93,7 @@ describe('StartFinishTimeInput', () => {
       const startTimeErrorMessage =
         'You must enter a start time in the HH:MM 24 hour clock format';
 
-      render(
+      renderWithTimecardContext(
         <StartFinishTimeInput
           name={'shift'}
           errors={{
@@ -86,6 +101,9 @@ describe('StartFinishTimeInput', () => {
             'shift-start-time': { message: startTimeErrorMessage },
           }}
           register={mockRegister}
+          timeEntry={timeEntry}
+          timeEntriesIndex={0}
+          getValues={jest.fn()}
         />
       );
 
@@ -103,7 +121,7 @@ describe('StartFinishTimeInput', () => {
       const expectedErrorMessage =
         'Error:You must enter a start time in the HH:MM 24 hour clock format';
 
-      render(
+      renderWithTimecardContext(
         <div>
           <StartFinishTimeInput
             name={'shift'}
@@ -113,6 +131,9 @@ describe('StartFinishTimeInput', () => {
               'shift-start-time': { message: startTimeErrorMessage },
             }}
             register={mockRegister}
+            timeEntry={timeEntry}
+            timeEntriesIndex={0}
+            getValues={jest.fn()}
           />
         </div>
       );

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
@@ -6,6 +6,9 @@ import StartFinishTimeInput from './StartFinishTimeInput';
 const mockRegister = jest.fn();
 const timeEntry = new ContextTimeEntry();
 
+const timeEntryWithFinishNextDay = new ContextTimeEntry();
+timeEntryWithFinishNextDay.setFinishNextDay(true);
+
 describe('StartFinishTimeInput', () => {
   it('should display titles for each input box', () => {
     renderWithTimecardContext(
@@ -86,6 +89,46 @@ describe('StartFinishTimeInput', () => {
 
     expect(startTimeInput.value).toBe('07:00');
     expect(finishTimeInput.value).toBe('17:00');
+  });
+
+  describe('Finishes next day', () => {
+    it('should display "Finishes next day" text if finishNextDay is true', () => {
+      renderWithTimecardContext(
+        <StartFinishTimeInput
+          name={'shift'}
+          startTimeValue="07:00"
+          finishTimeValue="01:00"
+          errors={{}}
+          register={mockRegister}
+          timeEntry={timeEntryWithFinishNextDay}
+          timeEntriesIndex={0}
+          getValues={jest.fn()}
+        />
+      );
+
+      const finishesNextDayText = screen.getByText('Finishes next day');
+
+      expect(finishesNextDayText).toBeTruthy();
+    });
+
+    it('should not display "Finishes next day" text if finishNextDay is false', () => {
+      renderWithTimecardContext(
+        <StartFinishTimeInput
+          name={'shift'}
+          startTimeValue="07:00"
+          finishTimeValue="17:00"
+          errors={{}}
+          register={mockRegister}
+          timeEntry={timeEntry}
+          timeEntriesIndex={0}
+          getValues={jest.fn()}
+        />
+      );
+
+      const finishesNextDayText = screen.queryByText('Finishes next day');
+
+      expect(finishesNextDayText).toBeFalsy();
+    });
   });
 
   describe('error messages', () => {

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -10,6 +10,7 @@ import { getTimeEntries } from '../../api/services/timecardService';
 import {
   formatTime,
   formatDate,
+  formatDateNoYear,
 } from '../../utils/time-entry-utils/timeEntryUtils';
 import { UrlSearchParamBuilder } from '../../utils/api-utils/UrlSearchParamBuilder';
 import { validateServiceErrors } from '../../utils/api-utils/ApiUtils';
@@ -155,6 +156,7 @@ const updateTimeEntryContextData = async (
               timeEntry.actualEndTime
                 ? formatTime(timeEntry.actualEndTime)
                 : '',
+              formatDateNoYear(timeEntry.actualEndTime),
               timeEntry.timePeriodTypeId
             )
         );

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -10,8 +10,8 @@ import { getTimeEntries } from '../../api/services/timecardService';
 import {
   formatDate,
   formatTime,
+  isFinishTimeOnNextDay,
 } from '../../utils/time-entry-utils/timeEntryUtils';
-import { initFinishNextDay } from '../../utils/time-entry-utils/ContextTimeEntry';
 import { UrlSearchParamBuilder } from '../../utils/api-utils/UrlSearchParamBuilder';
 import { validateServiceErrors } from '../../utils/api-utils/ApiUtils';
 import EditShiftTimecard from '../../components/timecard/edit-shift-timecard/EditShiftTimecard';
@@ -145,17 +145,19 @@ const updateTimeEntryContextData = async (
 
       if (timeEntriesResponse.data.items?.length > 0) {
         const existingTimeEntries = timeEntriesResponse.data.items.map(
-          (timeEntry) =>
-            new ContextTimeEntry(
+          (timeEntry) => {
+            return new ContextTimeEntry(
               timeEntry.id,
               timeEntry.actualStartTime,
               timeEntry.actualEndTime ? timeEntry.actualEndTime : '',
               timeEntry.timePeriodTypeId,
-              (timeEntry.finishNextDay = initFinishNextDay(
-                formatTime(timeEntry.actualStartTime),
-                formatTime(timeEntry.actualEndTime)
-              ))
-            )
+              timeEntry.finishNextDay ??
+                isFinishTimeOnNextDay(
+                  formatTime(timeEntry.actualStartTime),
+                  formatTime(timeEntry.actualEndTime)
+                )
+            );
+          }
         );
 
         setTimeEntries(existingTimeEntries);

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -10,8 +10,8 @@ import { getTimeEntries } from '../../api/services/timecardService';
 import {
   formatDate,
   formatTime,
-  isFinishTimeOnNextDay,
 } from '../../utils/time-entry-utils/timeEntryUtils';
+import { initFinishNextDay } from '../../utils/time-entry-utils/ContextTimeEntry';
 import { UrlSearchParamBuilder } from '../../utils/api-utils/UrlSearchParamBuilder';
 import { validateServiceErrors } from '../../utils/api-utils/ApiUtils';
 import EditShiftTimecard from '../../components/timecard/edit-shift-timecard/EditShiftTimecard';
@@ -151,7 +151,7 @@ const updateTimeEntryContextData = async (
               timeEntry.actualStartTime,
               timeEntry.actualEndTime ? timeEntry.actualEndTime : '',
               timeEntry.timePeriodTypeId,
-              (timeEntry.finishNextDay = isFinishTimeOnNextDay(
+              (timeEntry.finishNextDay = initFinishNextDay(
                 formatTime(timeEntry.actualStartTime),
                 formatTime(timeEntry.actualEndTime)
               ))

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -97,7 +97,7 @@ const Timecard = () => {
         <>
           {timeEntries.map((timeEntry, index) => (
             <div key={index} className="govuk-!-margin-bottom-6">
-              {renderTimeEntry(timePeriodTypesMap, timeEntry, index)}
+              {renderTimeEntry(timePeriodTypesMap, timeEntry, index, date)}
             </div>
           ))}
           <AddTimeCardPeriod timecardEmpty={timeEntries.length === 0} />
@@ -107,11 +107,15 @@ const Timecard = () => {
   );
 };
 
-const renderTimeEntry = (timePeriodTypesMap, timeEntry, index) => {
+const renderTimeEntry = (timePeriodTypesMap, timeEntry, index, date) => {
   switch (timePeriodTypesMap[timeEntry.timePeriodTypeId]) {
     case 'Shift':
       return (
-        <EditShiftTimecard timeEntry={timeEntry} timeEntriesIndex={index} />
+        <EditShiftTimecard
+          timeEntry={timeEntry}
+          timeEntriesIndex={index}
+          date={date}
+        />
       );
     default:
       return (

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -233,7 +233,7 @@ describe('Timecard', () => {
       newTimeEntry: false,
     });
 
-    expect(screen.getByText('08:00 to 16:00 on 01 July')).toBeInTheDocument();
+    expect(screen.getByText('08:00 to 16:00')).toBeInTheDocument();
     expect(screen.getByText('Add another time period')).toBeInTheDocument();
   });
 

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -119,9 +119,7 @@ describe('Timecard', () => {
           startTime: formatTime(
             shiftTimeEntryApiResponse.items[0].actualStartTime
           ),
-          finishTime: formatTime(
-            shiftTimeEntryApiResponse.items[0].actualEndTime
-          ),
+          finishTime: shiftTimeEntryApiResponse.items[0].actualEndTime,
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
         },
       ]);
@@ -227,7 +225,7 @@ describe('Timecard', () => {
         {
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
           startTime: '08:00',
-          finishTime: '16:00',
+          finishTime: '2022-02-02T16:00:00Z',
         },
       ],
       setTimeEntries: jest.fn(),

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -7,10 +7,7 @@ import {
 import { shiftTimeEntry } from '../../../mocks/mockData';
 import Timecard from './Timecard';
 import { getTimeEntries } from '../../api/services/timecardService';
-import {
-  addTimePeriodHeading,
-  formatTime,
-} from '../../utils/time-entry-utils/timeEntryUtils';
+import { addTimePeriodHeading } from '../../utils/time-entry-utils/timeEntryUtils';
 import { getApiResponseWithItems } from '../../../mocks/mock-utils';
 import { timeCardPeriodTypes } from '../../../mocks/mockData';
 
@@ -116,11 +113,10 @@ describe('Timecard', () => {
       expect(defaultTimecardContext.setTimeEntries).toHaveBeenCalledWith([
         {
           timeEntryId: 'c0a80040-82cf-1986-8182-cfedbbd50003',
-          startTime: formatTime(
-            shiftTimeEntryApiResponse.items[0].actualStartTime
-          ),
+          startTime: shiftTimeEntryApiResponse.items[0].actualStartTime,
           finishTime: shiftTimeEntryApiResponse.items[0].actualEndTime,
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          finishNextDay: false,
         },
       ]);
       expect(defaultTimecardContext.setTimecardDate).toHaveBeenCalledWith(date);
@@ -224,7 +220,7 @@ describe('Timecard', () => {
       timeEntries: [
         {
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
-          startTime: '08:00',
+          startTime: '2022-02-02T08:00:00Z',
           finishTime: '2022-02-02T16:00:00Z',
         },
       ],

--- a/src/pages/timecard/Timecard.spec.jsx
+++ b/src/pages/timecard/Timecard.spec.jsx
@@ -233,7 +233,7 @@ describe('Timecard', () => {
       newTimeEntry: false,
     });
 
-    expect(screen.getByText('08:00 to 16:00')).toBeInTheDocument();
+    expect(screen.getByText('08:00 to 16:00 on 01 July')).toBeInTheDocument();
     expect(screen.getByText('Add another time period')).toBeInTheDocument();
   });
 

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
@@ -5,7 +5,7 @@ import {
 } from '../resource-filter-builder/resourceFilterBuilder';
 
 export const filterTimeEntriesOnDate = (date) => {
-  const startOfDateFilter = filterOnOrAfterDate('actualStartTime', date);
+  const startOfDateFilter = filterOnOrAfterDate('actualEndTime', date);
   const endOfDateFilter = filterBeforeDate(
     'actualStartTime',
     dayjs(date).add(1, 'day')

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.spec.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.spec.js
@@ -8,12 +8,14 @@ describe('timeEntryFilterBuilder', () => {
       const dateTime = dayjs(date + ' 19:18:09');
       const filters = filterTimeEntriesOnDate(dateTime);
       expect(filters).toHaveLength(2);
-      expect(
-        filters.map((filter) => {
-          expect(filter).toContain('actualEndTime');
-          expect(filter).toContain(date);
-        })
-      );
+
+      // startOfDateFilter
+      expect(filters[0]).toContain('actualEndTime');
+      expect(filters[0]).toContain(date);
+
+      // endOfDateFilter
+      expect(filters[1]).toContain('actualStartTime');
+      expect(filters[1]).toContain(date);
     });
   });
 });

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.spec.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.spec.js
@@ -10,7 +10,7 @@ describe('timeEntryFilterBuilder', () => {
       expect(filters).toHaveLength(2);
       expect(
         filters.map((filter) => {
-          expect(filter).toContain('actualStartTime');
+          expect(filter).toContain('actualEndTime');
           expect(filter).toContain(date);
         })
       );

--- a/src/utils/time-entry-utils/ContextTimeEntry.js
+++ b/src/utils/time-entry-utils/ContextTimeEntry.js
@@ -3,7 +3,7 @@ export class ContextTimeEntry {
   startTime = '';
   finishTime = '';
   timePeriodTypeId = '';
-  finishNextDay = '';
+  finishNextDay = false;
 
   constructor(
     timeEntryId,
@@ -24,8 +24,8 @@ export class ContextTimeEntry {
       contextTimeEntry.timeEntryId,
       contextTimeEntry.startTime,
       contextTimeEntry.finishTime,
-      contextTimeEntry.finishNextDay,
-      contextTimeEntry.timePeriodTypeId
+      contextTimeEntry.timePeriodTypeId,
+      contextTimeEntry.finishNextDay
     );
   }
 

--- a/src/utils/time-entry-utils/ContextTimeEntry.js
+++ b/src/utils/time-entry-utils/ContextTimeEntry.js
@@ -2,21 +2,21 @@ export class ContextTimeEntry {
   timeEntryId = '';
   startTime = '';
   finishTime = '';
-  finishDate = '';
   timePeriodTypeId = '';
+  finishNextDay = '';
 
   constructor(
     timeEntryId,
     startTime,
     finishTime,
-    finishDate,
-    timePeriodTypeId
+    timePeriodTypeId,
+    finishNextDay
   ) {
     this.timeEntryId = timeEntryId ? timeEntryId : '';
     this.startTime = startTime ? startTime : '';
     this.finishTime = finishTime ? finishTime : '';
-    this.finishDate = finishDate ? finishDate : '';
     this.timePeriodTypeId = timePeriodTypeId ? timePeriodTypeId : '';
+    this.finishNextDay = finishNextDay ? finishNextDay : false;
   }
 
   static createFrom(contextTimeEntry) {
@@ -24,7 +24,7 @@ export class ContextTimeEntry {
       contextTimeEntry.timeEntryId,
       contextTimeEntry.startTime,
       contextTimeEntry.finishTime,
-      contextTimeEntry.finishDate,
+      contextTimeEntry.finishNextDay,
       contextTimeEntry.timePeriodTypeId
     );
   }
@@ -48,13 +48,13 @@ export class ContextTimeEntry {
     return this;
   }
 
-  setFinishDate(finishDate) {
-    this.finishDate = finishDate;
+  setTimePeriodTypeId(timePeriodTypeId) {
+    this.timePeriodTypeId = timePeriodTypeId;
     return this;
   }
 
-  setTimePeriodTypeId(timePeriodTypeId) {
-    this.timePeriodTypeId = timePeriodTypeId;
+  setFinishNextDay(finishNextDay) {
+    this.finishNextDay = finishNextDay;
     return this;
   }
 }

--- a/src/utils/time-entry-utils/ContextTimeEntry.js
+++ b/src/utils/time-entry-utils/ContextTimeEntry.js
@@ -1,5 +1,3 @@
-import { isFinishTimeOnNextDay } from './timeEntryUtils';
-
 export class ContextTimeEntry {
   timeEntryId = '';
   startTime = '';
@@ -58,9 +56,5 @@ export class ContextTimeEntry {
   setFinishNextDay(finishNextDay) {
     this.finishNextDay = finishNextDay;
     return this;
-  }
-
-  initFinishNextDay(startTime, endTime) {
-    return isFinishTimeOnNextDay(startTime, endTime);
   }
 }

--- a/src/utils/time-entry-utils/ContextTimeEntry.js
+++ b/src/utils/time-entry-utils/ContextTimeEntry.js
@@ -2,12 +2,20 @@ export class ContextTimeEntry {
   timeEntryId = '';
   startTime = '';
   finishTime = '';
+  finishDate = '';
   timePeriodTypeId = '';
 
-  constructor(timeEntryId, startTime, finishTime, timePeriodTypeId) {
+  constructor(
+    timeEntryId,
+    startTime,
+    finishTime,
+    finishDate,
+    timePeriodTypeId
+  ) {
     this.timeEntryId = timeEntryId ? timeEntryId : '';
     this.startTime = startTime ? startTime : '';
     this.finishTime = finishTime ? finishTime : '';
+    this.finishDate = finishDate ? finishDate : '';
     this.timePeriodTypeId = timePeriodTypeId ? timePeriodTypeId : '';
   }
 
@@ -16,6 +24,7 @@ export class ContextTimeEntry {
       contextTimeEntry.timeEntryId,
       contextTimeEntry.startTime,
       contextTimeEntry.finishTime,
+      contextTimeEntry.finishDate,
       contextTimeEntry.timePeriodTypeId
     );
   }
@@ -36,6 +45,11 @@ export class ContextTimeEntry {
 
   setFinishTime(finishTime) {
     this.finishTime = finishTime;
+    return this;
+  }
+
+  setFinishDate(finishDate) {
+    this.finishDate = finishDate;
     return this;
   }
 

--- a/src/utils/time-entry-utils/ContextTimeEntry.js
+++ b/src/utils/time-entry-utils/ContextTimeEntry.js
@@ -1,3 +1,5 @@
+import { isFinishTimeOnNextDay } from './timeEntryUtils';
+
 export class ContextTimeEntry {
   timeEntryId = '';
   startTime = '';
@@ -56,5 +58,9 @@ export class ContextTimeEntry {
   setFinishNextDay(finishNextDay) {
     this.finishNextDay = finishNextDay;
     return this;
+  }
+
+  initFinishNextDay(startTime, endTime) {
+    return isFinishTimeOnNextDay(startTime, endTime);
   }
 }

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -19,6 +19,10 @@ export const formatDate = (dateTime) => {
   return dayjs(dateTime).format('YYYY-MM-DD');
 };
 
+export const formatDateNoYear = (dateTime) => {
+  return dayjs(dateTime).format('DD MMMM');
+};
+
 export const formatDateTimeISO = (dateTime) => {
   return dayjs(dateTime).format('YYYY-MM-DDTHH:mm:ssZ');
 };

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -42,9 +42,9 @@ export const removeTimecardContextEntry = (
 
 export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   if (startTimeValue && finishTimeValue) {
-    return dayjs(
-      dayjs().format('YYYY-MM-DD') + '' + finishTimeValue
-    ).isSameOrBefore(dayjs(dayjs().format('YYYY-MM-DD') + '' + startTimeValue));
+    return dayjs(formatDate(dayjs()) + finishTimeValue).isSameOrBefore(
+      dayjs(formatDate(dayjs()) + startTimeValue)
+    );
   }
   return false;
 };

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -1,5 +1,8 @@
 import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { deepCloneJson } from '../common-utils/common-utils';
+
+dayjs.extend(isSameOrBefore);
 
 export const addTimePeriodHeading = 'Add time period';
 
@@ -39,9 +42,9 @@ export const removeTimecardContextEntry = (
 
 export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   if (startTimeValue && finishTimeValue) {
-    return dayjs(dayjs().format('YYYY-MM-DD') + '' + finishTimeValue).isBefore(
-      dayjs(dayjs().format('YYYY-MM-DD') + '' + startTimeValue)
-    );
+    return dayjs(
+      dayjs().format('YYYY-MM-DD') + '' + finishTimeValue
+    ).isSameOrBefore(dayjs(dayjs().format('YYYY-MM-DD') + '' + startTimeValue));
   }
   return false;
 };

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -30,3 +30,15 @@ export const removeTimecardContextEntry = (
   newTimeEntries.splice(removeAtIndex, 1);
   setTimeEntries(newTimeEntries);
 };
+
+export const calculateFinishTimeOnNextDay = (
+  startTimeValue,
+  finishTimeValue
+) => {
+  if (startTimeValue && finishTimeValue) {
+    return Math.floor(
+      parseFloat(startTimeValue.replace(/:/g, '.')).toFixed(2) /
+        parseFloat(finishTimeValue.replace(/:/g, '.')).toFixed(2)
+    );
+  }
+};

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -37,14 +37,11 @@ export const removeTimecardContextEntry = (
   setTimeEntries(newTimeEntries);
 };
 
-export const calculateFinishTimeOnNextDay = (
-  startTimeValue,
-  finishTimeValue
-) => {
+export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   if (startTimeValue && finishTimeValue) {
-    return Math.floor(
-      parseFloat(startTimeValue.replace(/:/g, '.')).toFixed(2) /
-        parseFloat(finishTimeValue.replace(/:/g, '.')).toFixed(2)
+    return dayjs(dayjs().format('YYYY-MM-DD') + '' + finishTimeValue).isBefore(
+      dayjs(dayjs().format('YYYY-MM-DD') + '' + startTimeValue)
     );
   }
+  return false;
 };

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -45,7 +45,7 @@ describe('timeEntryUtils', () => {
     expect(mockSetTimeEntries).toHaveBeenCalledWith([timeEntry1]);
   });
 
-  describe('calculateFinishTimeOnNextDay', () => {
+  describe('isFinishTimeOnNextDay', () => {
     it('should return true when finish time is before start time', async () => {
       const startTime = '12:03';
       const finishTime = '01:01';

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -46,25 +46,32 @@ describe('timeEntryUtils', () => {
   });
 
   describe('calculateFinishTimeOnNextDay', () => {
-    it('should return greater than 1', async () => {
+    it('should return true when finish time is before start time', async () => {
       const startTime = '12:03';
       const finishTime = '01:01';
 
       expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeTruthy();
     });
 
-    it('should return less than 1', async () => {
+    it('should return false when finish time is after start time', async () => {
       const startTime = '12:03';
       const finishTime = '12:04';
 
       expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeFalsy();
     });
 
-    it('should return nothing', async () => {
+    it('should return false when finish time is empty', async () => {
+      const startTime = '08:00';
+      const finishTime = '';
+
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeFalsy();
+    });
+
+    it('should return false when both start and finish time are empty', async () => {
       const startTime = '';
       const finishTime = '';
 
-      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeUndefined();
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeFalsy();
     });
   });
 });

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -1,6 +1,6 @@
 import { ContextTimeEntry } from './ContextTimeEntry';
 import {
-  calculateFinishTimeOnNextDay,
+  isFinishTimeOnNextDay,
   getSingleTimeEntryResponseItem,
   removeTimecardContextEntry,
 } from './timeEntryUtils';
@@ -50,27 +50,21 @@ describe('timeEntryUtils', () => {
       const startTime = '12:03';
       const finishTime = '01:01';
 
-      expect(
-        calculateFinishTimeOnNextDay(startTime, finishTime)
-      ).toBeGreaterThan(1);
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeTruthy();
     });
 
     it('should return less than 1', async () => {
       const startTime = '12:03';
       const finishTime = '12:04';
 
-      expect(calculateFinishTimeOnNextDay(startTime, finishTime)).toBeLessThan(
-        1
-      );
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeFalsy();
     });
 
     it('should return nothing', async () => {
       const startTime = '';
       const finishTime = '';
 
-      expect(
-        calculateFinishTimeOnNextDay(startTime, finishTime)
-      ).toBeUndefined();
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeUndefined();
     });
   });
 });

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -46,14 +46,28 @@ describe('timeEntryUtils', () => {
   });
 
   describe('isFinishTimeOnNextDay', () => {
-    it('should return true when finish time is before start time', async () => {
+    it('should return true when finish time is midnight', async () => {
       const startTime = '12:03';
-      const finishTime = '01:01';
+      const finishTime = '00:00';
 
       expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeTruthy();
     });
 
-    it('should return false when finish time is after start time', async () => {
+    it('should return true when start time equals finish time', async () => {
+      const startTime = '11:59';
+      const finishTime = '11:59';
+
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeTruthy();
+    });
+
+    it('should return true when start time is one minute before finish time', async () => {
+      const startTime = '12:35';
+      const finishTime = '12:34';
+
+      expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeTruthy();
+    });
+
+    it('should return false when finish time is one minute after start time', async () => {
       const startTime = '12:03';
       const finishTime = '12:04';
 

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -1,5 +1,6 @@
 import { ContextTimeEntry } from './ContextTimeEntry';
 import {
+  calculateFinishTimeOnNextDay,
   getSingleTimeEntryResponseItem,
   removeTimecardContextEntry,
 } from './timeEntryUtils';
@@ -42,5 +43,34 @@ describe('timeEntryUtils', () => {
     const mockSetTimeEntries = jest.fn();
     removeTimecardContextEntry(existingTimeEntries, mockSetTimeEntries, 1);
     expect(mockSetTimeEntries).toHaveBeenCalledWith([timeEntry1]);
+  });
+
+  describe('calculateFinishTimeOnNextDay', () => {
+    it('should return greater than 1', async () => {
+      const startTime = '12:03';
+      const finishTime = '01:01';
+
+      expect(
+        calculateFinishTimeOnNextDay(startTime, finishTime)
+      ).toBeGreaterThan(1);
+    });
+
+    it('should return less than 1', async () => {
+      const startTime = '12:03';
+      const finishTime = '12:04';
+
+      expect(calculateFinishTimeOnNextDay(startTime, finishTime)).toBeLessThan(
+        1
+      );
+    });
+
+    it('should return nothing', async () => {
+      const startTime = '';
+      const finishTime = '';
+
+      expect(
+        calculateFinishTimeOnNextDay(startTime, finishTime)
+      ).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
This PR also covers EAHW-1724. 
It contains the logic to add text and date to the screen when the user enters a finish time that is numerically before the start time. It will now assume this  finish time is on the next day and persist data accordingly. 

Added text added to the screen.
 
![image](https://user-images.githubusercontent.com/109532529/199233537-7c81cea0-5eda-4e5e-9d1a-0d7a503afefd.png)

![image](https://user-images.githubusercontent.com/109532529/199233598-90f28783-a6f4-4cf3-9024-12f769fee58b.png)
