### PR TITLE
EAHW-928: Fix accessibility error message

### DIFF
--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -61,9 +61,6 @@ const EditShiftHours = ({
       summaryErrors['shift-start-time'] = {
         message: 'Time periods must not overlap with another time period',
       };
-      summaryErrors['shift-finish-time'] = {
-        message: '',
-      };
     } else {
       errorsHandled = false;
     }

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -455,7 +455,6 @@ describe('EditShiftHours', () => {
           'shift-start-time': {
             message: 'Time periods must not overlap with another time period',
           },
-          'shift-finish-time': { message: '' },
         });
       });
     });


### PR DESCRIPTION
Fixes an issue that came out of accessibility testing where we are adding an empty error message on the finish time input field in order to add error styling. This change means that the finish time input box will never be red if there is a clashing shift, but that logic will be added in the next ticket (EAHW-2239)