### PR TITLE
EAHW-2190: Add SonarCloud link

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -132,3 +132,4 @@ steps:
         Repo: {{ repo.name }}
         Branch: <${DRONE_REPO_LINK}/commits/{{ build.branch }}|{{ build.branch }}>
         Author: {{ build.author }}
+        <https://sonarcloud.io/dashboard?id=callisto-ui&branch={{ build.branch }}&resolved=false|SonarCloud Analysis Report>


### PR DESCRIPTION
- Add link to SonarCloud report in Slack message
- Have to click 'Show More' to see the SonarCloud Analysis Report link

