### PR TITLE
Eahw 2239/show clashes in errors

### DIFF
--- a/src/components/common/form/date-input/DateInput.jsx
+++ b/src/components/common/form/date-input/DateInput.jsx
@@ -65,7 +65,7 @@ const DateInput = ({
               dateType="day"
               errors={errors}
               defaultValue={dayValue}
-              pattern={/^([1-9]|0[1-9]|[12][\d]|3[01])$/}
+              pattern={/^([1-9]|0[1-9]|[12]\d|3[01])$/}
               register={register}
             />
 
@@ -74,7 +74,7 @@ const DateInput = ({
               dateType="month"
               errors={errors}
               defaultValue={monthValue}
-              pattern={/^([1-9]|[0][1-9]|1[012])$/}
+              pattern={/^([1-9]|0[1-9]|1[012])$/}
               register={register}
             />
 

--- a/src/components/common/form/text-area/notes-summary-list/NotesSummaryList.jsx
+++ b/src/components/common/form/text-area/notes-summary-list/NotesSummaryList.jsx
@@ -7,7 +7,6 @@ const NotesSummaryList = () => {
   const [addNote, setAddNote] = useState(false);
 
   const handleClick = () => {
-    event.preventDefault();
     setAddNote(!addNote);
   };
 

--- a/src/components/common/form/text-area/notes-summary-list/NotesSummaryList.jsx
+++ b/src/components/common/form/text-area/notes-summary-list/NotesSummaryList.jsx
@@ -7,6 +7,7 @@ const NotesSummaryList = () => {
   const [addNote, setAddNote] = useState(false);
 
   const handleClick = () => {
+    event.preventDefault();
     setAddNote(!addNote);
   };
 

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import { useTimecardContext } from '../../../../context/TimecardContext';
 import { deepCloneJson } from '../../../../utils/common-utils/common-utils';
 import { ContextTimeEntry } from '../../../../utils/time-entry-utils/ContextTimeEntry';
-import { isFinishTimeOnNextDay } from '../../../../utils/time-entry-utils/timeEntryUtils';
+import {
+  inputNames,
+  isFinishTimeOnNextDay,
+} from '../../../../utils/time-entry-utils/timeEntryUtils';
 
 const ValidatedTimeEntry = ({
   name,
@@ -18,8 +21,8 @@ const ValidatedTimeEntry = ({
   const { timeEntries, setTimeEntries } = useTimecardContext();
 
   const setFinishTimeText = () => {
-    const startTimeValue = getFormValues('shift-start-time');
-    const finishTimeValue = getFormValues('shift-finish-time');
+    const startTimeValue = getFormValues(inputNames.shiftStartTime);
+    const finishTimeValue = getFormValues(inputNames.shiftFinishTime);
     const newTimeEntries = deepCloneJson(timeEntries);
 
     const answer = isFinishTimeOnNextDay(startTimeValue, finishTimeValue);

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.jsx
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types';
 import { useTimecardContext } from '../../../../context/TimecardContext';
 import { deepCloneJson } from '../../../../utils/common-utils/common-utils';
+import { inputNames } from '../../../../utils/constants';
 import { ContextTimeEntry } from '../../../../utils/time-entry-utils/ContextTimeEntry';
-import {
-  inputNames,
-  isFinishTimeOnNextDay,
-} from '../../../../utils/time-entry-utils/timeEntryUtils';
+import { isFinishTimeOnNextDay } from '../../../../utils/time-entry-utils/timeEntryUtils';
 
 const ValidatedTimeEntry = ({
   name,

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -46,7 +46,7 @@ describe('ValidatedTimeEntry', () => {
 
     const component = renderWithTimecardContext(
       <ValidatedTimeEntry
-        name="shift-finish-time"
+        name={inputNames.shiftFinishTime}
         timeType="finish time"
         errors={{}}
         register={setFinishTimeTextSpy}
@@ -57,8 +57,9 @@ describe('ValidatedTimeEntry', () => {
     );
 
     act(() => {
-      const someElement =
-        component.container.querySelector('#shift-finish-time');
+      const someElement = component.container.querySelector(
+        `#${inputNames.shiftFinishTime}`
+      );
       fireEvent.blur(someElement);
     });
 

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -4,6 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react-test-renderer';
 
 import ValidatedTimeEntry from './ValidatedTimeEntry';
+import { inputNames } from '../../../../utils/time-entry-utils/timeEntryUtils';
 
 describe('ValidatedTimeEntry', () => {
   const timeEntry = new ContextTimeEntry();
@@ -11,7 +12,7 @@ describe('ValidatedTimeEntry', () => {
   it('should render start time correctly', () => {
     const component = renderWithTimecardContext(
       <ValidatedTimeEntry
-        name="shift-start-time"
+        name={inputNames.shiftStartTime}
         timeType="start time"
         errors={{}}
         register={jest.fn()}
@@ -27,7 +28,7 @@ describe('ValidatedTimeEntry', () => {
   it('should render finish time correctly', () => {
     const component = renderWithTimecardContext(
       <ValidatedTimeEntry
-        name="shift-finish-time"
+        name={inputNames.shiftFinishTime}
         timeType="finish time"
         errors={{}}
         register={jest.fn()}

--- a/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
+++ b/src/components/common/validation/time-format/ValidatedTimeEntry.spec.jsx
@@ -4,7 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react-test-renderer';
 
 import ValidatedTimeEntry from './ValidatedTimeEntry';
-import { inputNames } from '../../../../utils/time-entry-utils/timeEntryUtils';
+import { inputNames } from '../../../../utils/constants';
 
 describe('ValidatedTimeEntry', () => {
   const timeEntry = new ContextTimeEntry();

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -12,11 +12,9 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import {
-  ClashingProperty,
   formatDate,
   formatDateTimeISO,
   formatTime,
-  inputNames,
 } from '../../../utils/time-entry-utils/timeEntryUtils';
 import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEntry';
 import {
@@ -27,6 +25,7 @@ import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useState } from 'react';
 import TimeInputErrors from '../time-input-errors/TimeInputErrors';
 import { useEffect } from 'react';
+import { ClashingProperty, inputNames } from '../../../utils/constants';
 
 const EditShiftHours = ({
   setShowEditShiftHours,

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -143,15 +143,20 @@ const EditShiftHours = ({
   };
 
   const getCombinedErrors = () => {
-    const combinedErrors = deepCloneJson(
-      Object.keys(errors).length > 0 ? errors : summaryErrors
-    );
+    var existingErrors =
+      Object.keys(errors).length > 0 ? errors : summaryErrors;
+
+    const combinedErrors = { ...existingErrors };
+
     if (wholeShiftClash) {
       combinedErrors['shift-finish-time'] = {
         message: '',
       };
     }
-    return combinedErrors;
+
+    console.log('here');
+    console.log(combinedErrors);
+    return combinedErrors; //Object.keys(errors).length > 0 ? errors : summaryErrors;
   };
 
   return (

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -87,7 +87,7 @@ const EditShiftHours = ({
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors['shift-finish-time'] = {
-          message: 'Your end time must not overlap with another time period',
+          message: 'Your finish time must not overlap with another time period',
         };
       } else {
         errorsHandled = false;
@@ -171,39 +171,23 @@ const EditShiftHours = ({
 
     const combinedErrors = { ...existingErrors };
 
-    if (clashingProperty === 'startAndEndTime') {
+    var timeInputErrors = (
+      <TimeInputErrors
+        clashingProperty={clashingProperty}
+        clashes={clashingTimes}
+      />
+    );
+
+    if (clashingProperty === 'startTime' || clashingProperty === 'endTime') {
       combinedErrors['shift-start-time'] = {
-        message: (
-          <TimeInputErrors
-            clashingProperty={clashingProperty}
-            clashes={clashingTimes}
-          />
-        ),
+        message: timeInputErrors,
+      };
+    } else if (clashingProperty === 'startAndEndTime') {
+      combinedErrors['shift-start-time'] = {
+        message: timeInputErrors,
       };
       combinedErrors['shift-finish-time'] = {
         message: '',
-      };
-    }
-
-    if (clashingProperty === 'startTime') {
-      combinedErrors['shift-start-time'] = {
-        message: (
-          <TimeInputErrors
-            clashingProperty={clashingProperty}
-            clashes={clashingTimes}
-          />
-        ),
-      };
-    }
-
-    if (clashingProperty === 'endTime') {
-      combinedErrors['shift-finish-time'] = {
-        message: (
-          <TimeInputErrors
-            clashingProperty={clashingProperty}
-            clashes={clashingTimes}
-          />
-        ),
       };
     }
 

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -12,6 +12,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import {
+  combineExistingAndTimeClashErrors,
   formatDate,
   formatDateTimeISO,
   formatTime,
@@ -22,9 +23,8 @@ import {
   focusErrors,
 } from '../../../utils/common-utils/common-utils';
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import TimeInputErrors from '../time-input-errors/TimeInputErrors';
-import { useEffect } from 'react';
 import { clashingProperties, inputNames } from '../../../utils/constants';
 
 const EditShiftHours = ({
@@ -176,46 +176,12 @@ const EditShiftHours = ({
     );
   };
 
-  const getCombinedErrors = () => {
-    const existingErrors =
-      Object.keys(errors).length > 0 ? errors : summaryErrors;
-
-    const combinedErrors = { ...existingErrors };
-
-    if (clashingProperty === clashingProperties.startAndEndTime) {
-      combinedErrors[inputNames.shiftStartTime] = {
-        message: (
-          <TimeInputErrors
-            clashingProperty={clashingProperty}
-            clashes={clashingTimes}
-          />
-        ),
-      };
-      combinedErrors[inputNames.shiftFinishTime] = {
-        message: '',
-      };
-    } else if (clashingProperty === clashingProperties.startTime) {
-      combinedErrors[inputNames.shiftStartTime] = {
-        message: (
-          <TimeInputErrors
-            clashingProperty={clashingProperty}
-            clashes={clashingTimes}
-          />
-        ),
-      };
-    } else if (clashingProperty === clashingProperties.endTime) {
-      combinedErrors[inputNames.shiftFinishTime] = {
-        message: (
-          <TimeInputErrors
-            clashingProperty={clashingProperty}
-            clashes={clashingTimes}
-          />
-        ),
-      };
-    }
-
-    return combinedErrors;
-  };
+  const getCombinedErrors = combineExistingAndTimeClashErrors(
+    errors,
+    summaryErrors,
+    clashingProperty,
+    clashingTimes
+  );
 
   return (
     <div>

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -62,33 +62,37 @@ const EditShiftHours = ({
     }
   };
 
-  const handleServerValidationErrors = (error) => {
-    if (error == null || !Array.isArray(error)) {
+  const handleServerValidationErrors = (errors) => {
+    if (errors == null || !Array.isArray(errors)) {
       return false;
     }
     const summaryErrors = {};
     let errorsHandled = true;
 
-    const firstError = error[0];
-    setClashingTimes(firstError.data);
-    setClashingProperty(firstError.field);
-
-    if (firstError.field == 'startAndEndTime') {
-      summaryErrors['shift-start-time'] = {
-        message:
-          'Your start and finish times must not overlap with another time period',
-      };
-    } else if (firstError.field == 'startTime') {
-      summaryErrors['shift-start-time'] = {
-        message: 'Your start time must not overlap with another time period',
-      };
-    } else if (firstError.field == 'endTime') {
-      summaryErrors['shift-finish-time'] = {
-        message: 'Your end time must not overlap with another time period',
-      };
-    } else {
-      errorsHandled = false;
-    }
+    errors.map((error) => {
+      if (error.field == 'startAndEndTime') {
+        setClashingTimes(error.data);
+        setClashingProperty(error.field);
+        summaryErrors['shift-start-time'] = {
+          message:
+            'Your start and finish times must not overlap with another time period',
+        };
+      } else if (error.field == 'startTime') {
+        setClashingTimes(error.data);
+        setClashingProperty(error.field);
+        summaryErrors['shift-start-time'] = {
+          message: 'Your start time must not overlap with another time period',
+        };
+      } else if (error.field == 'endTime') {
+        setClashingTimes(error.data);
+        setClashingProperty(error.field);
+        summaryErrors['shift-finish-time'] = {
+          message: 'Your end time must not overlap with another time period',
+        };
+      } else {
+        errorsHandled = false;
+      }
+    });
 
     if (errorsHandled) {
       setSummaryErrors(summaryErrors);

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -25,7 +25,7 @@ import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useState } from 'react';
 import TimeInputErrors from '../time-input-errors/TimeInputErrors';
 import { useEffect } from 'react';
-import { ClashingProperty, inputNames } from '../../../utils/constants';
+import { clashingProperties, inputNames } from '../../../utils/constants';
 
 const EditShiftHours = ({
   setShowEditShiftHours,
@@ -79,20 +79,20 @@ const EditShiftHours = ({
     const summaryErrors = {};
 
     errors.forEach((error) => {
-      if (error.field === ClashingProperty.startAndEndTime) {
+      if (error.field === clashingProperties.startAndEndTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors[inputNames.shiftStartTime] = {
           message:
             'Your start and finish times must not overlap with another time period',
         };
-      } else if (error.field === ClashingProperty.startTime) {
+      } else if (error.field === clashingProperties.startTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors[inputNames.shiftStartTime] = {
           message: 'Your start time must not overlap with another time period',
         };
-      } else if (error.field === ClashingProperty.endTime) {
+      } else if (error.field === clashingProperties.endTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors[inputNames.shiftFinishTime] = {
@@ -177,7 +177,7 @@ const EditShiftHours = ({
 
     const combinedErrors = { ...existingErrors };
 
-    if (clashingProperty === ClashingProperty.startAndEndTime) {
+    if (clashingProperty === clashingProperties.startAndEndTime) {
       combinedErrors[inputNames.shiftStartTime] = {
         message: (
           <TimeInputErrors
@@ -189,7 +189,7 @@ const EditShiftHours = ({
       combinedErrors[inputNames.shiftFinishTime] = {
         message: '',
       };
-    } else if (clashingProperty === ClashingProperty.startTime) {
+    } else if (clashingProperty === clashingProperties.startTime) {
       combinedErrors[inputNames.shiftStartTime] = {
         message: (
           <TimeInputErrors
@@ -198,7 +198,7 @@ const EditShiftHours = ({
           />
         ),
       };
-    } else if (clashingProperty === ClashingProperty.endTime) {
+    } else if (clashingProperty === clashingProperties.endTime) {
       combinedErrors[inputNames.shiftFinishTime] = {
         message: (
           <TimeInputErrors

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -175,19 +175,17 @@ const EditShiftHours = ({
     );
   };
 
-  const getCombinedErrors = combineExistingAndTimeClashErrors(
-    errors,
-    summaryErrors,
-    clashingProperty,
-    clashingTimes
-  );
-
   return (
     <div>
       <form onSubmit={handleSubmit(onSubmit, handleError)}>
         <StartFinishTimeInput
           name={inputName}
-          errors={getCombinedErrors()}
+          errors={combineExistingAndTimeClashErrors(
+            errors,
+            summaryErrors,
+            clashingProperty,
+            clashingTimes
+          )}
           register={register}
           formState={formState}
           getFormValues={getValues}

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -174,16 +174,24 @@ const EditShiftHours = ({
       />
     );
 
-    if (clashingProperty === 'startTime' || clashingProperty === 'endTime') {
-      combinedErrors['shift-start-time'] = {
-        message: timeInputErrors,
-      };
-    } else if (clashingProperty === 'startAndEndTime') {
+    if (clashingProperty === 'startAndEndTime') {
       combinedErrors['shift-start-time'] = {
         message: timeInputErrors,
       };
       combinedErrors['shift-finish-time'] = {
         message: '',
+      };
+    }
+
+    if (clashingProperty === 'startTime') {
+      combinedErrors['shift-start-time'] = {
+        message: timeInputErrors,
+      };
+    }
+
+    if (clashingProperty === 'endTime') {
+      combinedErrors['shift-finish-time'] = {
+        message: timeInputErrors,
       };
     }
 

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -75,7 +75,6 @@ const EditShiftHours = ({
           startTime
         )} to ${formatTime(endTime)} on ${formatDate(startTime)}`;
       } else {
-        console.log('here');
         text = `You are already assigned a scheduled rest day on ${formatDate(
           startTime
         )}`;
@@ -94,12 +93,18 @@ const EditShiftHours = ({
   };
 
   const handleServerValidationErrors = (error) => {
+    console.log(error);
+    if (error == null || !Array.isArray(error)) {
+      return false;
+    }
     const summaryErrors = {};
     let errorsHandled = true;
 
     var firstError = error[0];
     setClashingTimes(firstError.data);
     setClashingProperty(firstError.field);
+
+    console.log(firstError.field);
 
     if (firstError.field == 'startAndEndTime') {
       summaryErrors['shift-start-time'] = {
@@ -218,7 +223,7 @@ const EditShiftHours = ({
         ),
       };
     }
-    console.log(clashingProperty);
+
     if (clashingProperty == 'endTime') {
       combinedErrors['shift-finish-time'] = {
         message: (
@@ -230,8 +235,6 @@ const EditShiftHours = ({
       };
     }
 
-    console.log('here');
-    console.log(combinedErrors);
     return combinedErrors;
   };
 

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -67,7 +67,6 @@ const EditShiftHours = ({
       return false;
     }
     const summaryErrors = {};
-    let errorsHandled = true;
 
     errors.forEach((error) => {
       if (error.field === 'startAndEndTime') {
@@ -90,15 +89,12 @@ const EditShiftHours = ({
           message: 'Your finish time must not overlap with another time period',
         };
       } else {
-        errorsHandled = false;
+        return false;
       }
     });
 
-    if (errorsHandled) {
-      setSummaryErrors(summaryErrors);
-      return true;
-    }
-    return false;
+    setSummaryErrors(summaryErrors);
+    return true;
   };
 
   const onSubmit = async (formData) => {

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -54,18 +54,15 @@ const EditShiftHours = ({
   };
 
   const handleServerValidationErrors = (error) => {
-    console.log(error);
     if (error == null || !Array.isArray(error)) {
       return false;
     }
     const summaryErrors = {};
     let errorsHandled = true;
 
-    var firstError = error[0];
+    const firstError = error[0];
     setClashingTimes(firstError.data);
     setClashingProperty(firstError.field);
-
-    console.log(firstError.field);
 
     if (firstError.field == 'startAndEndTime') {
       summaryErrors['shift-start-time'] = {
@@ -74,11 +71,11 @@ const EditShiftHours = ({
       };
     } else if (firstError.field == 'startTime') {
       summaryErrors['shift-start-time'] = {
-        message: 'Your start time must not overlap with another period',
+        message: 'Your start time must not overlap with another time period',
       };
     } else if (firstError.field == 'endTime') {
       summaryErrors['shift-finish-time'] = {
-        message: 'Your end time must not overlap with another period',
+        message: 'Your end time must not overlap with another time period',
       };
     } else {
       errorsHandled = false;
@@ -152,7 +149,7 @@ const EditShiftHours = ({
   };
 
   const getCombinedErrors = () => {
-    var existingErrors =
+    const existingErrors =
       Object.keys(errors).length > 0 ? errors : summaryErrors;
 
     const combinedErrors = { ...existingErrors };

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -24,7 +24,6 @@ import {
 } from '../../../utils/common-utils/common-utils';
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useEffect, useState } from 'react';
-import TimeInputErrors from '../time-input-errors/TimeInputErrors';
 import { clashingProperties, inputNames } from '../../../utils/constants';
 
 const EditShiftHours = ({

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -156,6 +156,7 @@ const EditShiftHours = ({
           setShowEditShiftHours(false);
         }
       },
+      true,
       handleServerValidationErrors
     );
   };

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -169,31 +169,35 @@ const EditShiftHours = ({
 
     const combinedErrors = { ...existingErrors };
 
-    const timeInputErrors = (
-      <TimeInputErrors
-        clashingProperty={clashingProperty}
-        clashes={clashingTimes}
-      />
-    );
-
     if (clashingProperty === ClashingProperty.startAndEndTime) {
       combinedErrors[inputNames.shiftStartTime] = {
-        message: timeInputErrors,
+        message: (
+          <TimeInputErrors
+            clashingProperty={clashingProperty}
+            clashes={clashingTimes}
+          />
+        ),
       };
       combinedErrors[inputNames.shiftFinishTime] = {
         message: '',
       };
-    }
-
-    if (clashingProperty === ClashingProperty.startTime) {
+    } else if (clashingProperty === ClashingProperty.startTime) {
       combinedErrors[inputNames.shiftStartTime] = {
-        message: timeInputErrors,
+        message: (
+          <TimeInputErrors
+            clashingProperty={clashingProperty}
+            clashes={clashingTimes}
+          />
+        ),
       };
-    }
-
-    if (clashingProperty === ClashingProperty.endTime) {
+    } else if (clashingProperty === ClashingProperty.endTime) {
       combinedErrors[inputNames.shiftFinishTime] = {
-        message: timeInputErrors,
+        message: (
+          <TimeInputErrors
+            clashingProperty={clashingProperty}
+            clashes={clashingTimes}
+          />
+        ),
       };
     }
 

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -134,10 +134,10 @@ const EditShiftHours = ({
         const response = !timeEntry.timeEntryId
           ? await createTimeEntry(timecardPayload, params)
           : await updateTimeEntry(
-            timeEntry.timeEntryId,
-            timecardPayload,
-            params
-          );
+              timeEntry.timeEntryId,
+              timecardPayload,
+              params
+            );
 
         if (response?.data?.items?.length > 0) {
           const responseItem = response.data.items[0];

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -12,9 +12,11 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import {
+  ClashingProperty,
   formatDate,
   formatDateTimeISO,
   formatTime,
+  inputNames,
 } from '../../../utils/time-entry-utils/timeEntryUtils';
 import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEntry';
 import { deepCloneJson } from '../../../utils/common-utils/common-utils';
@@ -69,23 +71,23 @@ const EditShiftHours = ({
     const summaryErrors = {};
 
     errors.forEach((error) => {
-      if (error.field === 'startAndEndTime') {
+      if (error.field === ClashingProperty.startAndEndTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
-        summaryErrors['shift-start-time'] = {
+        summaryErrors[inputNames.shiftStartTime] = {
           message:
             'Your start and finish times must not overlap with another time period',
         };
-      } else if (error.field === 'startTime') {
+      } else if (error.field === ClashingProperty.startTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
-        summaryErrors['shift-start-time'] = {
+        summaryErrors[inputNames.shiftStartTime] = {
           message: 'Your start time must not overlap with another time period',
         };
-      } else if (error.field === 'endTime') {
+      } else if (error.field === ClashingProperty.endTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
-        summaryErrors['shift-finish-time'] = {
+        summaryErrors[inputNames.shiftFinishTime] = {
           message: 'Your finish time must not overlap with another time period',
         };
       } else {
@@ -167,30 +169,30 @@ const EditShiftHours = ({
 
     const combinedErrors = { ...existingErrors };
 
-    var timeInputErrors = (
+    const timeInputErrors = (
       <TimeInputErrors
         clashingProperty={clashingProperty}
         clashes={clashingTimes}
       />
     );
 
-    if (clashingProperty === 'startAndEndTime') {
-      combinedErrors['shift-start-time'] = {
+    if (clashingProperty === ClashingProperty.startAndEndTime) {
+      combinedErrors[inputNames.shiftStartTime] = {
         message: timeInputErrors,
       };
-      combinedErrors['shift-finish-time'] = {
+      combinedErrors[inputNames.shiftFinishTime] = {
         message: '',
       };
     }
 
-    if (clashingProperty === 'startTime') {
-      combinedErrors['shift-start-time'] = {
+    if (clashingProperty === ClashingProperty.startTime) {
+      combinedErrors[inputNames.shiftStartTime] = {
         message: timeInputErrors,
       };
     }
 
-    if (clashingProperty === 'endTime') {
-      combinedErrors['shift-finish-time'] = {
+    if (clashingProperty === ClashingProperty.endTime) {
+      combinedErrors[inputNames.shiftFinishTime] = {
         message: timeInputErrors,
       };
     }

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -12,7 +12,6 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { UrlSearchParamBuilder } from '../../../utils/api-utils/UrlSearchParamBuilder';
 import {
-  combineExistingAndTimeClashErrors,
   formatDate,
   formatDateTimeISO,
   formatTime,
@@ -25,6 +24,7 @@ import {
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useEffect, useState } from 'react';
 import { clashingProperties, inputNames } from '../../../utils/constants';
+import { combineExistingAndTimeClashErrors } from '../../../utils/time-entry-utils/combineTimeErrors';
 
 const EditShiftHours = ({
   setShowEditShiftHours,

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -77,8 +77,9 @@ const EditShiftHours = ({
       return false;
     }
     const summaryErrors = {};
+    let errorsHandled = true;
 
-    errors.forEach((error) => {
+    for (const error of errors) {
       if (error.field === clashingProperties.startAndEndTime) {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
@@ -99,12 +100,16 @@ const EditShiftHours = ({
           message: 'Your finish time must not overlap with another time period',
         };
       } else {
-        return false;
+        errorsHandled = false;
+        break;
       }
-    });
+    }
+    if (errorsHandled) {
+      setSummaryErrors(summaryErrors);
+      return true;
+    }
 
-    setSummaryErrors(summaryErrors);
-    return true;
+    return false;
   };
 
   const onSubmit = async (formData) => {

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -63,27 +63,27 @@ const EditShiftHours = ({
   };
 
   const handleServerValidationErrors = (errors) => {
-    if (errors == null || !Array.isArray(errors)) {
+    if (errors === null || !Array.isArray(errors)) {
       return false;
     }
     const summaryErrors = {};
     let errorsHandled = true;
 
     errors.forEach((error) => {
-      if (error.field == 'startAndEndTime') {
+      if (error.field === 'startAndEndTime') {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors['shift-start-time'] = {
           message:
             'Your start and finish times must not overlap with another time period',
         };
-      } else if (error.field == 'startTime') {
+      } else if (error.field === 'startTime') {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors['shift-start-time'] = {
           message: 'Your start time must not overlap with another time period',
         };
-      } else if (error.field == 'endTime') {
+      } else if (error.field === 'endTime') {
         setClashingTimes(error.data);
         setClashingProperty(error.field);
         summaryErrors['shift-finish-time'] = {
@@ -134,10 +134,10 @@ const EditShiftHours = ({
         const response = !timeEntry.timeEntryId
           ? await createTimeEntry(timecardPayload, params)
           : await updateTimeEntry(
-              timeEntry.timeEntryId,
-              timecardPayload,
-              params
-            );
+            timeEntry.timeEntryId,
+            timecardPayload,
+            params
+          );
 
         if (response?.data?.items?.length > 0) {
           const responseItem = response.data.items[0];
@@ -171,7 +171,7 @@ const EditShiftHours = ({
 
     const combinedErrors = { ...existingErrors };
 
-    if (clashingProperty == 'startAndEndTime') {
+    if (clashingProperty === 'startAndEndTime') {
       combinedErrors['shift-start-time'] = {
         message: (
           <TimeInputErrors
@@ -185,7 +185,7 @@ const EditShiftHours = ({
       };
     }
 
-    if (clashingProperty == 'startTime') {
+    if (clashingProperty === 'startTime') {
       combinedErrors['shift-start-time'] = {
         message: (
           <TimeInputErrors
@@ -196,7 +196,7 @@ const EditShiftHours = ({
       };
     }
 
-    if (clashingProperty == 'endTime') {
+    if (clashingProperty === 'endTime') {
       combinedErrors['shift-finish-time'] = {
         message: (
           <TimeInputErrors

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -69,7 +69,7 @@ const EditShiftHours = ({
     const summaryErrors = {};
     let errorsHandled = true;
 
-    errors.map((error) => {
+    errors.forEach((error) => {
       if (error.field == 'startAndEndTime') {
         setClashingTimes(error.data);
         setClashingProperty(error.field);

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.jsx
@@ -20,6 +20,7 @@ import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEnt
 import { deepCloneJson } from '../../../utils/common-utils/common-utils';
 import { validateServiceErrors } from '../../../utils/api-utils/ApiUtils';
 import { useState } from 'react';
+import TimeInputErrors from '../time-input-errors/TimeInputErrors';
 
 const EditShiftHours = ({
   setShowEditShiftHours,
@@ -50,46 +51,6 @@ const EditShiftHours = ({
 
   const handleError = (errorFields) => {
     setSummaryErrors(errorFields);
-  };
-
-  const formatTimeClashes = (timeClashes) => {
-    if (timeClashes.length > 1) {
-      var times = (
-        <div>
-          <p>You are already assigned to the following time periods:</p>
-          <ul>
-            {timeClashes.map((clash) => (
-              <li key="foo">{shiftClashToText(clash)}</li>
-            ))}
-          </ul>
-        </div>
-      );
-      return times;
-    } else {
-      var clash = timeClashes[0];
-      var startTime = Date.parse(clash.startTime);
-      var endTime = Date.parse(clash.endTime);
-      var text;
-      if (clash.timePeriodTypeId == '00000000-0000-0000-0000-000000000001') {
-        text = `You are already assigned to work from ${formatTime(
-          startTime
-        )} to ${formatTime(endTime)} on ${formatDate(startTime)}`;
-      } else {
-        text = `You are already assigned a scheduled rest day on ${formatDate(
-          startTime
-        )}`;
-      }
-      return <p>{text}</p>;
-    }
-  };
-
-  const shiftClashToText = (clash) => {
-    var startTime = Date.parse(clash.startTime);
-    var endTime = Date.parse(clash.endTime);
-    var clashText = `${formatTime(startTime)} to ${formatTime(
-      endTime
-    )} on ${formatDate(startTime)}`;
-    return clashText;
   };
 
   const handleServerValidationErrors = (error) => {
@@ -199,13 +160,10 @@ const EditShiftHours = ({
     if (clashingProperty == 'startAndEndTime') {
       combinedErrors['shift-start-time'] = {
         message: (
-          <div>
-            <p>
-              Your start and finish times must not overlap with another time
-              period
-            </p>
-            {formatTimeClashes(clashingTimes)}
-          </div>
+          <TimeInputErrors
+            clashingProperty={clashingProperty}
+            clashes={clashingTimes}
+          />
         ),
       };
       combinedErrors['shift-finish-time'] = {
@@ -216,10 +174,10 @@ const EditShiftHours = ({
     if (clashingProperty == 'startTime') {
       combinedErrors['shift-start-time'] = {
         message: (
-          <div>
-            <p>Your start time must not overlap with another period</p>
-            {formatTimeClashes(clashingTimes)}
-          </div>
+          <TimeInputErrors
+            clashingProperty={clashingProperty}
+            clashes={clashingTimes}
+          />
         ),
       };
     }
@@ -227,10 +185,10 @@ const EditShiftHours = ({
     if (clashingProperty == 'endTime') {
       combinedErrors['shift-finish-time'] = {
         message: (
-          <div>
-            <p>Your end time must not overlap with another period</p>
-            {formatTimeClashes(clashingTimes)}
-          </div>
+          <TimeInputErrors
+            clashingProperty={clashingProperty}
+            clashes={clashingTimes}
+          />
         ),
       };
     }

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -18,7 +18,7 @@ import {
 import { expectNeverToHappen } from '../../../test/helpers/Helpers';
 import { deepCloneJson } from '../../../utils/common-utils/common-utils';
 
-import { ClashingProperty, inputNames } from '../../../utils/constants';
+import { clashingProperties, inputNames } from '../../../utils/constants';
 
 const newTimeEntry = {
   timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -494,7 +494,7 @@ describe('EditShiftHours', () => {
           response: {
             data: [
               {
-                field: ClashingProperty.startAndEndTime,
+                field: clashingProperties.startAndEndTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -545,7 +545,7 @@ describe('EditShiftHours', () => {
           response: {
             data: [
               {
-                field: ClashingProperty.startTime,
+                field: clashingProperties.startTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -598,7 +598,7 @@ describe('EditShiftHours', () => {
           response: {
             data: [
               {
-                field: ClashingProperty.endTime,
+                field: clashingProperties.endTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -435,7 +435,60 @@ describe('EditShiftHours', () => {
   );
 
   describe('Service errors', () => {
-    it('should set time entry clashing errors in summaryErrors when error is returned from the server', async () => {
+    it('should set time entry clashing errors in summaryErrors when error is returned from the server for start and end time', async () => {
+      createTimeEntry.mockImplementation(() => {
+        throw {
+          response: {
+            data: [
+              {
+                field: 'startAndEndTime',
+                data: [
+                  {
+                    timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+                    startTime: null,
+                    endTime: null,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      });
+
+      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
+      mockTimecardContext.setSummaryErrors = jest.fn();
+
+      renderWithTimecardContext(
+        <EditShiftHours
+          setShowEditShiftHours={jest.fn()}
+          timeEntry={newTimeEntry}
+          timeEntriesIndex={0}
+        />,
+        mockTimecardContext
+      );
+
+      const startTimeInput = screen.getByTestId('shift-start-time');
+      const finishTimeInput = screen.getByTestId('shift-finish-time');
+
+      fireEvent.change(startTimeInput, { target: { value: '1201' } });
+      fireEvent.change(finishTimeInput, { target: { value: '2201' } });
+
+      act(() => {
+        const saveButton = screen.getByText('Save');
+        fireEvent.click(saveButton);
+      });
+
+      await waitFor(() => {
+        expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
+          'shift-start-time': {
+            message:
+            'Your start and finish times must not overlap with another time period',
+          },
+        });
+      });
+    });
+
+    it('should set time entry clashing errors in summaryErrors when error is returned from the server for start time', async () => {
       createTimeEntry.mockImplementation(() => {
         throw {
           response: {
@@ -481,7 +534,59 @@ describe('EditShiftHours', () => {
       await waitFor(() => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
           'shift-start-time': {
-            message: 'Your start time must not overlap with another period',
+            message: 'Your start time must not overlap with another time period',
+          },
+        });
+      });
+    });
+
+    it('should set time entry clashing errors in summaryErrors when error is returned from the server for end time', async () => {
+      createTimeEntry.mockImplementation(() => {
+        throw {
+          response: {
+            data: [
+              {
+                field: 'endTime',
+                data: [
+                  {
+                    timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+                    startTime: null,
+                    endTime: null,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      });
+
+      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
+      mockTimecardContext.setSummaryErrors = jest.fn();
+
+      renderWithTimecardContext(
+        <EditShiftHours
+          setShowEditShiftHours={jest.fn()}
+          timeEntry={newTimeEntry}
+          timeEntriesIndex={0}
+        />,
+        mockTimecardContext
+      );
+
+      const startTimeInput = screen.getByTestId('shift-start-time');
+      const finishTimeInput = screen.getByTestId('shift-finish-time');
+
+      fireEvent.change(startTimeInput, { target: { value: '1201' } });
+      fireEvent.change(finishTimeInput, { target: { value: '2201' } });
+
+      act(() => {
+        const saveButton = screen.getByText('Save');
+        fireEvent.click(saveButton);
+      });
+
+      await waitFor(() => {
+        expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
+          'shift-finish-time': {
+            message: 'Your end time must not overlap with another time period',
           },
         });
       });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -442,7 +442,13 @@ describe('EditShiftHours', () => {
             data: [
               {
                 field: 'startTime',
-                data: [{ timePeriodTypeId: 0, startTime: null, endTime: null }],
+                data: [
+                  {
+                    timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+                    startTime: null,
+                    endTime: null,
+                  },
+                ],
               },
             ],
           },

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -482,7 +482,7 @@ describe('EditShiftHours', () => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
           'shift-start-time': {
             message:
-            'Your start and finish times must not overlap with another time period',
+              'Your start and finish times must not overlap with another time period',
           },
         });
       });
@@ -534,7 +534,8 @@ describe('EditShiftHours', () => {
       await waitFor(() => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
           'shift-start-time': {
-            message: 'Your start time must not overlap with another time period',
+            message:
+              'Your start time must not overlap with another time period',
           },
         });
       });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -636,7 +636,8 @@ describe('EditShiftHours', () => {
       await waitFor(() => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
           'shift-finish-time': {
-            message: 'Your end time must not overlap with another time period',
+            message:
+              'Your finish time must not overlap with another time period',
           },
         });
       });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -533,7 +533,7 @@ describe('EditShiftHours', () => {
 
       await waitFor(() => {
         expect(defaultTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
-          'shift-start-time': {
+          [inputNames.shiftStartTime]: {
             message:
               'Your start and finish times must not overlap with another time period',
           },
@@ -586,7 +586,7 @@ describe('EditShiftHours', () => {
 
       await waitFor(() => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
-          'shift-start-time': {
+          [inputNames.shiftStartTime]: {
             message:
               'Your start time must not overlap with another time period',
           },
@@ -639,7 +639,7 @@ describe('EditShiftHours', () => {
 
       await waitFor(() => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
-          'shift-finish-time': {
+          [inputNames.shiftFinishTime]: {
             message:
               'Your finish time must not overlap with another time period',
           },
@@ -807,12 +807,12 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const startTimeInput = screen.getByTestId('shift-start-time');
+        const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
         fireEvent.change(startTimeInput, {
           target: { value: '08:00' },
         });
 
-        const endTimeInput = screen.getByTestId('shift-finish-time');
+        const endTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
         fireEvent.change(endTimeInput, {
           target: { value: '01:00' },
         });
@@ -861,12 +861,12 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const startTimeInput = screen.getByTestId('shift-start-time');
+        const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
         fireEvent.change(startTimeInput, {
           target: { value: '' },
         });
 
-        const endTimeInput = screen.getByTestId('shift-finish-time');
+        const endTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
         fireEvent.change(endTimeInput, {
           target: { value: '01:00' },
         });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -17,6 +17,10 @@ import {
 } from '../../../../mocks/mockData';
 import { expectNeverToHappen } from '../../../test/helpers/Helpers';
 import { deepCloneJson } from '../../../utils/common-utils/common-utils';
+import {
+  ClashingProperty,
+  inputNames,
+} from '../../../utils/time-entry-utils/timeEntryUtils';
 
 const newTimeEntry = {
   timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -63,7 +67,7 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const startTimeInput = screen.getByTestId('shift-start-time');
+        const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
         fireEvent.change(startTimeInput, {
           target: { value: inputtedStartTime },
         });
@@ -110,12 +114,12 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const startTimeInput = screen.getByTestId('shift-start-time');
+        const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
         fireEvent.change(startTimeInput, {
           target: { value: inputtedStartTime },
         });
 
-        const endTimeInput = screen.getByTestId('shift-finish-time');
+        const endTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
         fireEvent.change(endTimeInput, {
           target: { value: inputtedEndTime },
         });
@@ -161,7 +165,7 @@ describe('EditShiftHours', () => {
         );
 
         act(() => {
-          const startTimeInput = screen.getByTestId('shift-start-time');
+          const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
           fireEvent.change(startTimeInput, {
             target: { value: inputtedStartTime },
           });
@@ -198,7 +202,7 @@ describe('EditShiftHours', () => {
         );
 
         act(() => {
-          const startTimeInput = screen.getByTestId('shift-start-time');
+          const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
           fireEvent.change(startTimeInput, {
             target: { value: inputtedStartTime },
           });
@@ -232,8 +236,8 @@ describe('EditShiftHours', () => {
       />
     );
 
-    const startTimeInput = screen.getByTestId('shift-start-time');
-    const finishTimeInput = screen.getByTestId('shift-finish-time');
+    const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+    const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
     fireEvent.change(startTimeInput, { target: { value: '1201' } });
     fireEvent.change(finishTimeInput, { target: { value: '2201' } });
@@ -269,7 +273,7 @@ describe('EditShiftHours', () => {
       />
     );
 
-    const startTimeInput = screen.getByTestId('shift-start-time');
+    const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
     fireEvent.change(startTimeInput, { target: { value: '1201' } });
 
     act(() => {
@@ -324,7 +328,7 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const startTimeInput = screen.getByTestId('shift-start-time');
+        const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
         fireEvent.change(startTimeInput, { target: { value: testValue } });
 
         const saveButton = screen.getByText('Save');
@@ -352,7 +356,7 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const startTimeInput = screen.getByTestId('shift-start-time');
+        const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
         fireEvent.change(startTimeInput, { target: { value: testValue } });
 
         const saveButton = screen.getByText('Save');
@@ -381,7 +385,7 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const finishTimeInput = screen.getByTestId('shift-finish-time');
+        const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
         fireEvent.change(finishTimeInput, { target: { value: testValue } });
 
         const saveButton = screen.getByText('Save');
@@ -409,7 +413,7 @@ describe('EditShiftHours', () => {
       );
 
       act(() => {
-        const finishTimeInput = screen.getByTestId('shift-finish-time');
+        const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
         fireEvent.change(finishTimeInput, { target: { value: testValue } });
 
         const saveButton = screen.getByText('Save');
@@ -455,12 +459,12 @@ describe('EditShiftHours', () => {
     );
 
     act(() => {
-      const startTimeInput = screen.getByTestId('shift-start-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
       fireEvent.change(startTimeInput, {
         target: { value: '08:00' },
       });
 
-      const endTimeInput = screen.getByTestId('shift-finish-time');
+      const endTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
       fireEvent.change(endTimeInput, {
         target: { value: '01:00' },
       });
@@ -492,7 +496,7 @@ describe('EditShiftHours', () => {
           response: {
             data: [
               {
-                field: 'startAndEndTime',
+                field: ClashingProperty.startAndEndTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -516,8 +520,8 @@ describe('EditShiftHours', () => {
         defaultTimecardContext
       );
 
-      const startTimeInput = screen.getByTestId('shift-start-time');
-      const finishTimeInput = screen.getByTestId('shift-finish-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+      const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
       fireEvent.change(startTimeInput, { target: { value: '1201' } });
       fireEvent.change(finishTimeInput, { target: { value: '2201' } });
@@ -543,7 +547,7 @@ describe('EditShiftHours', () => {
           response: {
             data: [
               {
-                field: 'startTime',
+                field: ClashingProperty.startTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -569,8 +573,8 @@ describe('EditShiftHours', () => {
         mockTimecardContext
       );
 
-      const startTimeInput = screen.getByTestId('shift-start-time');
-      const finishTimeInput = screen.getByTestId('shift-finish-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+      const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
       fireEvent.change(startTimeInput, { target: { value: '1201' } });
       fireEvent.change(finishTimeInput, { target: { value: '2201' } });
@@ -596,7 +600,7 @@ describe('EditShiftHours', () => {
           response: {
             data: [
               {
-                field: 'endTime',
+                field: ClashingProperty.endTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -622,8 +626,8 @@ describe('EditShiftHours', () => {
         mockTimecardContext
       );
 
-      const startTimeInput = screen.getByTestId('shift-start-time');
-      const finishTimeInput = screen.getByTestId('shift-finish-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+      const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
       fireEvent.change(startTimeInput, { target: { value: '1201' } });
       fireEvent.change(finishTimeInput, { target: { value: '2201' } });
@@ -669,8 +673,8 @@ describe('EditShiftHours', () => {
         mockTimecardContext
       );
 
-      const startTimeInput = screen.getByTestId('shift-start-time');
-      const finishTimeInput = screen.getByTestId('shift-finish-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+      const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
       fireEvent.change(startTimeInput, { target: { value: '1201' } });
       fireEvent.change(finishTimeInput, { target: { value: '2201' } });
@@ -695,7 +699,7 @@ describe('EditShiftHours', () => {
                 data: [],
               },
               {
-                field: 'endTime',
+                field: ClashingProperty.endTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
@@ -721,8 +725,8 @@ describe('EditShiftHours', () => {
         mockTimecardContext
       );
 
-      const startTimeInput = screen.getByTestId('shift-start-time');
-      const finishTimeInput = screen.getByTestId('shift-finish-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+      const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
       fireEvent.change(startTimeInput, { target: { value: '1201' } });
       fireEvent.change(finishTimeInput, { target: { value: '2201' } });
@@ -758,8 +762,8 @@ describe('EditShiftHours', () => {
         defaultTimecardContext
       );
 
-      const startTimeInput = screen.getByTestId('shift-start-time');
-      const finishTimeInput = screen.getByTestId('shift-finish-time');
+      const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+      const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
       fireEvent.change(startTimeInput, { target: { value: '1201' } });
       fireEvent.change(finishTimeInput, { target: { value: '2201' } });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -419,10 +419,12 @@ describe('EditShiftHours', () => {
       createTimeEntry.mockImplementation(() => {
         throw {
           response: {
-            data: {
-              message:
-                ' has the following error(s): Time periods must not overlap with another time period',
-            },
+            data: [
+              {
+                field: 'startTime',
+                data: [{ timePeriodTypeId: 0, startTime: null, endTime: null }],
+              },
+            ],
           },
         };
       });
@@ -453,7 +455,7 @@ describe('EditShiftHours', () => {
       await waitFor(() => {
         expect(mockTimecardContext.setSummaryErrors).toHaveBeenCalledWith({
           'shift-start-time': {
-            message: 'Time periods must not overlap with another time period',
+            message: 'Your start time must not overlap with another period',
           },
         });
       });

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -697,7 +697,7 @@ describe('EditShiftHours', () => {
                 data: [],
               },
               {
-                field: ClashingProperty.endTime,
+                field: clashingProperties.endTime,
                 data: [
                   {
                     timePeriodTypeId: '00000000-0000-0000-0000-000000000001',

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -593,6 +593,48 @@ describe('EditShiftHours', () => {
       });
     });
 
+    it('should not set summary errors for responses other than time clashes', async () => {
+      createTimeEntry.mockImplementation(() => {
+        throw {
+          response: {
+            data: [
+              {
+                field: 'ownerId',
+                data: [],
+              },
+            ],
+          },
+        };
+      });
+
+      const mockTimecardContext = deepCloneJson(defaultTimecardContext);
+      mockTimecardContext.setSummaryErrors = jest.fn();
+
+      renderWithTimecardContext(
+        <EditShiftHours
+          setShowEditShiftHours={jest.fn()}
+          timeEntry={newTimeEntry}
+          timeEntriesIndex={0}
+        />,
+        mockTimecardContext
+      );
+
+      const startTimeInput = screen.getByTestId('shift-start-time');
+      const finishTimeInput = screen.getByTestId('shift-finish-time');
+
+      fireEvent.change(startTimeInput, { target: { value: '1201' } });
+      fireEvent.change(finishTimeInput, { target: { value: '2201' } });
+
+      act(() => {
+        const saveButton = screen.getByText('Save');
+        fireEvent.click(saveButton);
+      });
+
+      await waitFor(() => {
+        expect(mockTimecardContext.setSummaryErrors).not.toHaveBeenCalled();
+      });
+    });
+
     it('should not set errors in summaryErrors when unhandled error is returned from the server', async () => {
       createTimeEntry.mockImplementation(() => {
         throw {

--- a/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
+++ b/src/components/timecard/edit-shift-hours/EditShiftHours.spec.jsx
@@ -17,10 +17,8 @@ import {
 } from '../../../../mocks/mockData';
 import { expectNeverToHappen } from '../../../test/helpers/Helpers';
 import { deepCloneJson } from '../../../utils/common-utils/common-utils';
-import {
-  ClashingProperty,
-  inputNames,
-} from '../../../utils/time-entry-utils/timeEntryUtils';
+
+import { ClashingProperty, inputNames } from '../../../utils/constants';
 
 const newTimeEntry = {
   timePeriodTypeId: '00000000-0000-0000-0000-000000000001',

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -20,7 +20,7 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
   };
 
   const { setServiceError } = useApplicationContext();
-  const { timeEntries, setTimeEntries } = useTimecardContext();
+  const { timeEntries, setTimeEntries, setSummaryErrors } = useTimecardContext();
 
   const timeEntryExists = !!timeEntry?.startTime;
   const [showEditShiftHours, setShowEditShiftHours] = useState(
@@ -33,6 +33,7 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
       .setTenantId('00000000-0000-0000-0000-000000000000')
       .getUrlSearchParams();
 
+    setSummaryErrors({});
     validateServiceErrors(setServiceError, async () => {
       await deleteTimeEntry(timeEntry.timeEntryId, params);
       removeTimecardContextEntry(timeEntries, setTimeEntries, timeEntriesIndex);

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -20,7 +20,8 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
   };
 
   const { setServiceError } = useApplicationContext();
-  const { timeEntries, setTimeEntries, setSummaryErrors } = useTimecardContext();
+  const { timeEntries, setTimeEntries, setSummaryErrors } =
+    useTimecardContext();
 
   const timeEntryExists = !!timeEntry?.startTime;
   const [showEditShiftHours, setShowEditShiftHours] = useState(

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -80,10 +80,12 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
           >
             {!showEditShiftHours &&
               timeEntryExists &&
-              `${formatTime(timeEntry.startTime)} to ${timeEntry.finishTime ? formatTime(timeEntry.finishTime) : '-'
-              } ${timeEntry.finishNextDay
-                ? ` on ${formatDateNoYear(timeEntry.finishTime)}`
-                : ''
+              `${formatTime(timeEntry.startTime)} to ${
+                timeEntry.finishTime ? formatTime(timeEntry.finishTime) : '-'
+              } ${
+                timeEntry.finishNextDay
+                  ? ` on ${formatDateNoYear(timeEntry.finishTime)}`
+                  : ''
               }`}
           </dd>
           <dd className="govuk-summary-list__actions">

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.jsx
@@ -80,12 +80,10 @@ const EditShiftTimecard = ({ timeEntry, timeEntriesIndex }) => {
           >
             {!showEditShiftHours &&
               timeEntryExists &&
-              `${formatTime(timeEntry.startTime)} to ${
-                timeEntry.finishTime ? formatTime(timeEntry.finishTime) : '-'
-              } ${
-                timeEntry.finishNextDay
-                  ? ` on ${formatDateNoYear(timeEntry.finishTime)}`
-                  : ''
+              `${formatTime(timeEntry.startTime)} to ${timeEntry.finishTime ? formatTime(timeEntry.finishTime) : '-'
+              } ${timeEntry.finishNextDay
+                ? ` on ${formatDateNoYear(timeEntry.finishTime)}`
+                : ''
               }`}
           </dd>
           <dd className="govuk-summary-list__actions">

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -12,6 +12,7 @@ import {
   defaultTimecardContext,
   renderWithTimecardContext,
 } from '../../../test/helpers/TimecardContext';
+import { inputNames } from '../../../utils/time-entry-utils/timeEntryUtils';
 import EditShiftTimecard from './EditShiftTimecard';
 
 jest.mock('../../../api/services/timecardService');
@@ -68,8 +69,8 @@ describe('EditShiftTimecard', () => {
       <EditShiftTimecard timeEntry={newTimeEntry} timeEntriesIndex={0} />
     );
 
-    const startTimeInput = screen.getByTestId('shift-start-time');
-    const finishTimeInput = screen.getByTestId('shift-finish-time');
+    const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+    const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
     fireEvent.change(startTimeInput, { target: { value: '08:00' } });
     fireEvent.change(finishTimeInput, { target: { value: '16:00' } });

--- a/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
+++ b/src/components/timecard/edit-shift-timecard/EditShiftTimecard.spec.jsx
@@ -12,7 +12,7 @@ import {
   defaultTimecardContext,
   renderWithTimecardContext,
 } from '../../../test/helpers/TimecardContext';
-import { inputNames } from '../../../utils/time-entry-utils/timeEntryUtils';
+import { inputNames } from '../../../utils/constants';
 import EditShiftTimecard from './EditShiftTimecard';
 
 jest.mock('../../../api/services/timecardService');

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ValidatedTimeEntry from '../../common/validation/time-format/ValidatedTimeEntry';
 import { sortErrorKeys } from '../../../utils/sort-errors/sortErrors';
-import { inputNames } from '../../../utils/time-entry-utils/timeEntryUtils';
+import { inputNames } from '../../../utils/constants';
 
 const StartFinishTimeInput = ({
   name,

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -40,14 +40,14 @@ const StartFinishTimeInput = ({
     >
       <div className="govuk-grid-row" data-testid="error-box">
         {sortErrorKeys(errors, desiredErrorOrder).map((error, i) => (
-          <p
+          <div
             id={`${name}-${i}-error`}
             key={i}
             className="govuk-error-message govuk-!-margin-left-3"
           >
             <span className="govuk-visually-hidden">Error:</span>
             {errors[error]?.message}
-          </p>
+          </div>
         ))}
       </div>
 

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ValidatedTimeEntry from '../../common/validation/time-format/ValidatedTimeEntry';
 import { sortErrorKeys } from '../../../utils/sort-errors/sortErrors';
+import { inputNames } from '../../../utils/time-entry-utils/timeEntryUtils';
 
 const StartFinishTimeInput = ({
   name,
@@ -16,7 +17,10 @@ const StartFinishTimeInput = ({
 }) => {
   const [errorMessages, setErrorMessages] = useState([]);
 
-  const desiredErrorOrder = ['shift-start-time', 'shift-finish-time'];
+  const desiredErrorOrder = [
+    inputNames.shiftStartTime,
+    inputNames.shiftFinishTime,
+  ];
 
   useEffect(() => {
     updateErrorMessages();

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.jsx
@@ -48,8 +48,12 @@ const StartFinishTimeInput = ({
             key={i}
             className="govuk-error-message govuk-!-margin-left-3"
           >
-            <span className="govuk-visually-hidden">Error:</span>
-            {errors[error]?.message}
+            {errors[error]?.message && (
+              <div>
+                <span className="govuk-visually-hidden">Error:</span>
+                {errors[error]?.message}
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
@@ -142,7 +142,7 @@ describe('StartFinishTimeInput', () => {
           name={'shift'}
           errors={{
             'radio-error': { message: 'Select a radio button' }, // error message for another component
-            'shift-start-time': { message: startTimeErrorMessage },
+            [inputNames.shiftStartTime]: { message: startTimeErrorMessage },
           }}
           register={mockRegister}
           timeEntry={timeEntry}
@@ -171,8 +171,8 @@ describe('StartFinishTimeInput', () => {
             name={'shift'}
             errors={{
               'radio-error': { message: 'Select a radio button' }, // error message for another component
-              'shift-finish-time': { message: finishTimeErrorMessage },
-              'shift-start-time': { message: startTimeErrorMessage },
+              [inputNames.shiftFinishTime]: { message: finishTimeErrorMessage },
+              [inputNames.shiftStartTime]: { message: startTimeErrorMessage },
             }}
             register={mockRegister}
             timeEntry={timeEntry}

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
 import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEntry';
+import { inputNames } from '../../../utils/time-entry-utils/timeEntryUtils';
 import StartFinishTimeInput from './StartFinishTimeInput';
 
 const mockRegister = jest.fn();
@@ -60,8 +61,8 @@ describe('StartFinishTimeInput', () => {
       />
     );
 
-    const startTimeInput = screen.getByTestId('shift-start-time');
-    const finishTimeInput = screen.getByTestId('shift-finish-time');
+    const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+    const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
     fireEvent.change(startTimeInput, { target: { value: '08:00' } });
     fireEvent.change(finishTimeInput, { target: { value: '16:00' } });
@@ -84,8 +85,8 @@ describe('StartFinishTimeInput', () => {
       />
     );
 
-    const startTimeInput = screen.getByTestId('shift-start-time');
-    const finishTimeInput = screen.getByTestId('shift-finish-time');
+    const startTimeInput = screen.getByTestId(inputNames.shiftStartTime);
+    const finishTimeInput = screen.getByTestId(inputNames.shiftFinishTime);
 
     expect(startTimeInput.value).toBe('07:00');
     expect(finishTimeInput.value).toBe('17:00');

--- a/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
+++ b/src/components/timecard/start-finish-time-input/StartFinishTimeInput.spec.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
+import { inputNames } from '../../../utils/constants';
 import { ContextTimeEntry } from '../../../utils/time-entry-utils/ContextTimeEntry';
-import { inputNames } from '../../../utils/time-entry-utils/timeEntryUtils';
 import StartFinishTimeInput from './StartFinishTimeInput';
 
 const mockRegister = jest.fn();

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -91,11 +91,9 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const formatStartDateTime = (clash) => {
-    const startTime = new Date(clash.startTime);
-    const endTime = new Date(clash.endTime);
     let startDate = '';
 
-    if (!dayjs(startTime).isSame(endTime, 'day')) {
+    if (!dayjs(clash.startTime).isSame(clash.endTime, 'day')) {
       startDate = ` on ${formatLongDate(clash.startTime)}`;
     }
 

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,21 +1,60 @@
 import { PropTypes } from 'prop-types';
+import {
+  formatDate,
+  formatTime,
+} from '../../../utils/time-entry-utils/timeEntryUtils';
 
-const TimeInputErrors = ({ clashingProperty }) => {
-  switch (clashingProperty) {
-    case 'startTime':
-      return <p>Your start time must not overlap with another time period</p>;
-    case 'endTime':
-      return <p>Your finish time must not overlap with another time period</p>;
-    default:
-      return (
-        <p>
-          Your start and finish times must not overlap with another time period
-        </p>
-      );
-  }
+const TimeInputErrors = ({ clashingProperty, clashes }) => {
+  const displayClashingProperty = () => {
+    switch (clashingProperty) {
+      case 'startTime':
+        return <p>Your start time must not overlap with another time period</p>;
+      case 'endTime':
+        return (
+          <p>Your finish time must not overlap with another time period</p>
+        );
+      default:
+        return (
+          <p>
+            Your start and finish times must not overlap with another time
+            period
+          </p>
+        );
+    }
+  };
+
+  const displayTimeClashes = () => {
+    const clash = clashes[0];
+    const startTime = Date.parse(clash.startTime);
+    const endTime = Date.parse(clash.endTime);
+    let text;
+    if (clash.timePeriodTypeId == '00000000-0000-0000-0000-000000000001') {
+      text = `You are already assigned to work from ${formatTime(
+        startTime
+      )} to ${formatTime(endTime)} on ${formatDate(startTime)}`;
+    } else {
+      text = `You are already assigned a scheduled rest day on ${formatDate(
+        startTime
+      )}`;
+    }
+    return <p>{text}</p>;
+  };
+
+  return (
+    <>
+      {displayClashingProperty()} {displayTimeClashes()}
+    </>
+  );
 };
 
 export default TimeInputErrors;
 TimeInputErrors.propTypes = {
   clashingProperty: PropTypes.string.isRequired,
+  clashes: PropTypes.arrayOf(
+    PropTypes.shape({
+      timePeriodTypeId: PropTypes.string,
+      startTime: PropTypes.string,
+      endTime: PropTypes.string,
+    })
+  ).isRequired,
 };

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -2,7 +2,6 @@ import dayjs from 'dayjs';
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 import {
-  formatDate,
   formatTime,
   getTimePeriodTypesMap,
 } from '../../../utils/time-entry-utils/timeEntryUtils';
@@ -57,7 +56,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
         <p>You are already assigned to the following time periods:</p>
         <ul>
           {clashes.map((clash, index) => (
-            <li key={index}>{shiftClashToText(clash)}</li>
+            <li key={index}>{timePeriodClashToText(clash)}</li>
           ))}
         </ul>
       </div>
@@ -65,13 +64,21 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     return times;
   };
 
-  const shiftClashToText = (clash) => {
+  const timePeriodClashToText = (clash) => {
     var startTime = Date.parse(clash.startTime);
     var endTime = Date.parse(clash.endTime);
-    var clashText = `${formatTime(startTime)} to ${formatTime(
-      endTime
-    )} on ${dayjs(startTime).format('D MMMM YYYY')}`;
-    return clashText;
+
+    const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
+    switch (timePeriodType) {
+      case 'Shift':
+        return `${formatTime(startTime)} to ${formatTime(endTime)} on ${dayjs(
+          startTime
+        ).format('D MMMM YYYY')}`;
+      default:
+        return `${timePeriodType.toLowerCase()} on ${dayjs(startTime).format(
+          'D MMMM YYYY'
+        )}`;
+    }
   };
 
   return (

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,0 +1,21 @@
+import { PropTypes } from 'prop-types';
+
+const TimeInputErrors = ({ clashingProperty }) => {
+  switch (clashingProperty) {
+    case 'startTime':
+      return <p>Your start time must not overlap with another time period</p>;
+    case 'endTime':
+      return <p>Your finish time must not overlap with another time period</p>;
+    default:
+      return (
+        <p>
+          Your start and finish times must not overlap with another time period
+        </p>
+      );
+  }
+};
+
+export default TimeInputErrors;
+TimeInputErrors.propTypes = {
+  clashingProperty: PropTypes.string.isRequired,
+};

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 import {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -27,6 +27,11 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const displaySingleTimeClash = () => {
+    if (clashes.length === 0) {
+      throw new Error(
+        'The time clashes data did not contain at least one time clash.'
+      );
+    }
     const clash = clashes[0];
     let text;
 

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -51,7 +51,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const displayMultipleTimeClashes = () => {
-    var times = (
+    const times = (
       <div>
         <p>You are already assigned to the following time periods:</p>
         <ul>
@@ -65,8 +65,8 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const timePeriodClashToText = (clash) => {
-    var startTime = Date.parse(clash.startTime);
-    var endTime = Date.parse(clash.endTime);
+    const startTime = Date.parse(clash.startTime);
+    const endTime = Date.parse(clash.endTime);
 
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
     switch (timePeriodType) {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
+import { ClashingProperty } from '../../../utils/constants';
 import {
-  ClashingProperty,
   formatLongDate,
   formatTime,
   getTimePeriodTypesMap,

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 import {
@@ -94,7 +95,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const endTime = new Date(clash.endTime);
     let startDate = '';
 
-    if (startTime.toDateString() !== endTime.toDateString()) {
+    if (!dayjs(startTime).isSame(endTime, 'day')) {
       startDate = ` on ${formatLongDate(clash.startTime)}`;
     }
 

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -51,17 +51,27 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const displayMultipleTimeClashes = () => {
+    sortClashes(clashes);
+
     const times = (
       <div>
         <p>You are already assigned to the following time periods:</p>
         <ul>
           {clashes.map((clash, index) => (
-            <li key={index}>{timePeriodClashToText(clash)}</li>
+            <li key={index} data-testid="test">
+              {timePeriodClashToText(clash)}
+            </li>
           ))}
         </ul>
       </div>
     );
     return times;
+  };
+
+  const sortClashes = (clashes) => {
+    return clashes.sort(
+      (a, b) => Date.parse(a.startTime) - Date.parse(b.startTime)
+    );
   };
 
   const timePeriodClashToText = (clash) => {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -33,7 +33,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
 
     if (timePeriodType === 'Shift') {
-      text = `You are already assigned to work from ${startDateTime(
+      text = `You are already assigned to work from ${formatStartDateTime(
         clash
       )} to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`;
     } else {
@@ -73,7 +73,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
 
     if (timePeriodType === 'Shift') {
-      return `${startDateTime(clash)} to ${formatTime(
+      return `${formatStartDateTime(clash)} to ${formatTime(
         clash.endTime
       )} on ${formatLongDate(clash.endTime)}`;
     }
@@ -83,7 +83,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     )}`;
   };
 
-  const startDateTime = (clash) => {
+  const formatStartDateTime = (clash) => {
     const startTime = new Date(clash.startTime);
     const endTime = new Date(clash.endTime);
     let startDate = '';

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -30,21 +30,30 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
 
   const displaySingleTimeClash = () => {
     const clash = clashes[0];
-    const startTime = Date.parse(clash.startTime);
-    const endTime = Date.parse(clash.endTime);
+    const startTime = new Date(clash.startTime);
+    const endTime = new Date(clash.endTime);
     let text;
+
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
     switch (timePeriodType) {
       case 'Shift':
-        text = `You are already assigned to work from ${formatTime(
-          startTime
-        )} to ${formatTime(endTime)} on ${dayjs(startTime).format(
-          'D MMMM YYYY'
-        )}`;
+        if (startTime.toDateString() === endTime.toDateString()) {
+          text = `You are already assigned to work from ${formatTime(
+            clash.startTime
+          )} to ${formatTime(clash.endTime)} on ${dayjs(clash.startTime).format(
+            'D MMMM YYYY'
+          )}`;
+        } else {
+          text = `You are already assigned to work from ${formatTime(
+            clash.startTime
+          )} on ${dayjs(clash.startTime).format('D MMMM YYYY')} to ${formatTime(
+            clash.endTime
+          )} on ${dayjs(clash.endTime).format('D MMMM YYYY')}`;
+        }
         break;
       default:
         text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${dayjs(
-          startTime
+          clash.startTime
         ).format('D MMMM YYYY')}`;
     }
     return <p>{text}</p>;
@@ -75,19 +84,16 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const timePeriodClashToText = (clash) => {
-    const startTime = Date.parse(clash.startTime);
-    const endTime = Date.parse(clash.endTime);
-
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
     switch (timePeriodType) {
       case 'Shift':
-        return `${formatTime(startTime)} to ${formatTime(endTime)} on ${dayjs(
-          startTime
-        ).format('D MMMM YYYY')}`;
+        return `${formatTime(clash.startTime)} to ${formatTime(
+          clash.endTime
+        )} on ${dayjs(clash.startTime).format('D MMMM YYYY')}`;
       default:
-        return `${timePeriodType.toLowerCase()} on ${dayjs(startTime).format(
-          'D MMMM YYYY'
-        )}`;
+        return `${timePeriodType.toLowerCase()} on ${dayjs(
+          clash.startTime
+        ).format('D MMMM YYYY')}`;
     }
   };
 

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,6 +1,7 @@
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 import {
+  ClashingProperty,
   formatLongDate,
   formatTime,
   getTimePeriodTypesMap,
@@ -11,11 +12,11 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   const timePeriodTypesMap = getTimePeriodTypesMap(timePeriodTypes);
 
   const displayClashingProperty = () => {
-    if (clashingProperty === 'startTime') {
+    if (clashingProperty === ClashingProperty.startTime) {
       return <p>Your start time must not overlap with another time period</p>;
     }
 
-    if (clashingProperty === 'endTime') {
+    if (clashingProperty === ClashingProperty.endTime) {
       return <p>Your finish time must not overlap with another time period</p>;
     }
 
@@ -51,7 +52,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   };
 
   const displayMultipleTimeClashes = () => {
-    sortClashes(clashes);
+    sortByStartTime(clashes);
 
     const times = (
       <div>
@@ -68,7 +69,7 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     return times;
   };
 
-  const sortClashes = (clashes) => {
+  const sortByStartTime = (clashes) => {
     return clashes.sort(
       (a, b) => Date.parse(a.startTime) - Date.parse(b.startTime)
     );

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -11,21 +11,19 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   const timePeriodTypesMap = getTimePeriodTypesMap(timePeriodTypes);
 
   const displayClashingProperty = () => {
-    switch (clashingProperty) {
-      case 'startTime':
-        return <p>Your start time must not overlap with another time period</p>;
-      case 'endTime':
-        return (
-          <p>Your finish time must not overlap with another time period</p>
-        );
-      default:
-        return (
-          <p>
-            Your start and finish times must not overlap with another time
-            period
-          </p>
-        );
+    if (clashingProperty === 'startTime') {
+      return <p>Your start time must not overlap with another time period</p>;
     }
+
+    if (clashingProperty === 'endTime') {
+      return <p>Your finish time must not overlap with another time period</p>;
+    }
+
+    return (
+      <p>
+        Your start and finish times must not overlap with another time period
+      </p>
+    );
   };
 
   const displaySingleTimeClash = () => {
@@ -33,17 +31,17 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     let text;
 
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
-    switch (timePeriodType) {
-      case 'Shift':
-        text = `You are already assigned to work from ${startDateTime(
-          clash
-        )} to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`;
-        break;
-      default:
-        text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${formatLongDate(
-          clash.startTime
-        )}`;
+
+    if (timePeriodType === 'Shift') {
+      text = `You are already assigned to work from ${startDateTime(
+        clash
+      )} to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`;
+    } else {
+      text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${formatLongDate(
+        clash.startTime
+      )}`;
     }
+
     return <p>{text}</p>;
   };
 
@@ -73,16 +71,16 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
 
   const timePeriodClashToText = (clash) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
-    switch (timePeriodType) {
-      case 'Shift':
-        return `${startDateTime(clash)} to ${formatTime(
-          clash.endTime
-        )} on ${formatLongDate(clash.endTime)}`;
-      default:
-        return `${timePeriodType.toLowerCase()} on ${formatLongDate(
-          clash.startTime
-        )}`;
+
+    if (timePeriodType === 'Shift') {
+      return `${startDateTime(clash)} to ${formatTime(
+        clash.endTime
+      )} on ${formatLongDate(clash.endTime)}`;
     }
+
+    return `${timePeriodType.toLowerCase()} on ${formatLongDate(
+      clash.startTime
+    )}`;
   };
 
   const startDateTime = (clash) => {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
 import {
+  formatLongDate,
   formatTime,
   getTimePeriodTypesMap,
 } from '../../../utils/time-entry-utils/timeEntryUtils';
@@ -30,31 +31,19 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
 
   const displaySingleTimeClash = () => {
     const clash = clashes[0];
-    const startTime = new Date(clash.startTime);
-    const endTime = new Date(clash.endTime);
     let text;
 
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
     switch (timePeriodType) {
       case 'Shift':
-        if (startTime.toDateString() === endTime.toDateString()) {
-          text = `You are already assigned to work from ${formatTime(
-            clash.startTime
-          )} to ${formatTime(clash.endTime)} on ${dayjs(clash.startTime).format(
-            'D MMMM YYYY'
-          )}`;
-        } else {
-          text = `You are already assigned to work from ${formatTime(
-            clash.startTime
-          )} on ${dayjs(clash.startTime).format('D MMMM YYYY')} to ${formatTime(
-            clash.endTime
-          )} on ${dayjs(clash.endTime).format('D MMMM YYYY')}`;
-        }
+        text = `You are already assigned to work from ${startDateTime(
+          clash
+        )} to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`;
         break;
       default:
-        text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${dayjs(
+        text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${formatLongDate(
           clash.startTime
-        ).format('D MMMM YYYY')}`;
+        )}`;
     }
     return <p>{text}</p>;
   };
@@ -87,14 +76,26 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
     switch (timePeriodType) {
       case 'Shift':
-        return `${formatTime(clash.startTime)} to ${formatTime(
+        return `${startDateTime(clash)} to ${formatTime(
           clash.endTime
-        )} on ${dayjs(clash.startTime).format('D MMMM YYYY')}`;
+        )} on ${formatLongDate(clash.endTime)}`;
       default:
-        return `${timePeriodType.toLowerCase()} on ${dayjs(
+        return `${timePeriodType.toLowerCase()} on ${formatLongDate(
           clash.startTime
-        ).format('D MMMM YYYY')}`;
+        )}`;
     }
+  };
+
+  const startDateTime = (clash) => {
+    const startTime = new Date(clash.startTime);
+    const endTime = new Date(clash.endTime);
+    let startDate = '';
+
+    if (startTime.toDateString() !== endTime.toDateString()) {
+      startDate = ` on ${formatLongDate(clash.startTime)}`;
+    }
+
+    return `${formatTime(clash.startTime)}${startDate}`;
   };
 
   return (

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { PropTypes } from 'prop-types';
 import { useApplicationContext } from '../../../context/ApplicationContext';
-import { ClashingProperty } from '../../../utils/constants';
+import { clashingProperties } from '../../../utils/constants';
 import {
   formatLongDate,
   formatTime,
@@ -13,11 +13,11 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
   const timePeriodTypesMap = getTimePeriodTypesMap(timePeriodTypes);
 
   const displayClashingProperty = () => {
-    if (clashingProperty === ClashingProperty.startTime) {
+    if (clashingProperty === clashingProperties.startTime) {
       return <p>Your start time must not overlap with another time period</p>;
     }
 
-    if (clashingProperty === ClashingProperty.endTime) {
+    if (clashingProperty === clashingProperties.endTime) {
       return <p>Your finish time must not overlap with another time period</p>;
     }
 

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -1,6 +1,6 @@
 import { getNodeText, screen } from '@testing-library/react';
 import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
-import { ClashingProperty } from '../../../utils/time-entry-utils/timeEntryUtils';
+import { ClashingProperty } from '../../../utils/constants';
 import TimeInputErrors from './TimeInputErrors';
 
 describe('TimeInputErrors', () => {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { getNodeText, screen } from '@testing-library/react';
 import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
 import TimeInputErrors from './TimeInputErrors';
 
@@ -222,6 +222,47 @@ describe('TimeInputErrors', () => {
       expect(clashingTimePeriodError).toBeTruthy();
       expect(clashingNWD).toBeTruthy();
       expect(clashingSRD).toBeTruthy();
+    });
+
+    it('should display time clashes in chronological order by start time', () => {
+      const shiftAndSRDClashes = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-04T12:00:00.000+00:00',
+          endTime: '2022-11-05T16:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000003',
+          startTime: '2022-11-03T00:00:00.000+00:00',
+          endTime: '2022-11-04T00:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-04T08:00:00.000+00:00',
+          endTime: '2022-11-05T12:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={shiftAndSRDClashes}
+        />
+      );
+
+      const clashingTimePeriods = screen
+        .getAllByTestId('test')
+        .map(getNodeText);
+
+      expect(clashingTimePeriods[0]).toEqual(
+        'non-working day on 3 November 2022'
+      );
+      expect(clashingTimePeriods[1]).toEqual(
+        '08:00 to 12:00 on 4 November 2022'
+      );
+      expect(clashingTimePeriods[2]).toEqual(
+        '12:00 to 16:00 on 4 November 2022'
+      );
     });
   });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -1,6 +1,6 @@
 import { getNodeText, screen } from '@testing-library/react';
 import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
-import { ClashingProperty } from '../../../utils/constants';
+import { clashingProperties } from '../../../utils/constants';
 import TimeInputErrors from './TimeInputErrors';
 
 describe('TimeInputErrors', () => {
@@ -16,7 +16,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for start time clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={singleShiftClash}
         />
       );
@@ -30,7 +30,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for finish time clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.endTime}
+          clashingProperty={clashingProperties.endTime}
           clashes={singleShiftClash}
         />
       );
@@ -44,7 +44,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for start and finish time clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startAndEndTime}
+          clashingProperty={clashingProperties.startAndEndTime}
           clashes={singleShiftClash}
         />
       );
@@ -60,7 +60,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for shift clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={singleShiftClash}
         />
       );
@@ -82,7 +82,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={singleScheduledRestDayClash}
         />
       );
@@ -104,7 +104,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={singleNonWorkingDayClash}
         />
       );
@@ -133,7 +133,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={twoShiftClashes}
         />
       );
@@ -169,7 +169,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -205,7 +205,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -246,7 +246,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -282,7 +282,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -312,7 +312,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={shiftClash}
         />
       );
@@ -340,7 +340,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={ClashingProperty.startTime}
+          clashingProperty={clashingProperties.startTime}
           clashes={shiftClash}
         />
       );

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -1,5 +1,6 @@
 import { getNodeText, screen } from '@testing-library/react';
 import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
+import { ClashingProperty } from '../../../utils/time-entry-utils/timeEntryUtils';
 import TimeInputErrors from './TimeInputErrors';
 
 describe('TimeInputErrors', () => {
@@ -15,7 +16,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for start time clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={singleShiftClash}
         />
       );
@@ -29,7 +30,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for finish time clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'endTime'}
+          clashingProperty={ClashingProperty.endTime}
           clashes={singleShiftClash}
         />
       );
@@ -43,7 +44,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for start and finish time clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startAndEndTime'}
+          clashingProperty={ClashingProperty.startAndEndTime}
           clashes={singleShiftClash}
         />
       );
@@ -59,7 +60,7 @@ describe('TimeInputErrors', () => {
     it('should display a single error for shift clash', () => {
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={singleShiftClash}
         />
       );
@@ -81,7 +82,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={singleScheduledRestDayClash}
         />
       );
@@ -103,7 +104,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={singleNonWorkingDayClash}
         />
       );
@@ -132,7 +133,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={twoShiftClashes}
         />
       );
@@ -168,7 +169,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -204,7 +205,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -245,7 +246,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -281,7 +282,7 @@ describe('TimeInputErrors', () => {
 
       renderWithTimecardContext(
         <TimeInputErrors
-          clashingProperty={'startTime'}
+          clashingProperty={ClashingProperty.startTime}
           clashes={shiftAndSRDClashes}
         />
       );
@@ -310,7 +311,10 @@ describe('TimeInputErrors', () => {
       ];
 
       renderWithTimecardContext(
-        <TimeInputErrors clashingProperty={'startTime'} clashes={shiftClash} />
+        <TimeInputErrors
+          clashingProperty={ClashingProperty.startTime}
+          clashes={shiftClash}
+        />
       );
 
       const clashingShiftError = screen.getByText(
@@ -335,7 +339,10 @@ describe('TimeInputErrors', () => {
       ];
 
       renderWithTimecardContext(
-        <TimeInputErrors clashingProperty={'startTime'} clashes={shiftClash} />
+        <TimeInputErrors
+          clashingProperty={ClashingProperty.startTime}
+          clashes={shiftClash}
+        />
       );
 
       const firstClashingShiftError = screen.getByText(

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -2,30 +2,93 @@ import { render, screen } from '@testing-library/react';
 import TimeInputErrors from './TimeInputErrors';
 
 describe('TimeInputErrors', () => {
-  it('should display a single error for start time clash', () => {
-    render(<TimeInputErrors clashingProperty={'startTime'} />);
+  const singleShiftClash = [
+    {
+      timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+      startTime: '2022-11-07T08:00:00.000+00:00',
+      endTime: '2022-11-07T12:00:00.000+00:00',
+    },
+  ];
 
-    const clashingShiftError = screen.getByText(
-      'Your start time must not overlap with another time period'
-    );
-    expect(clashingShiftError).toBeTruthy();
+  const singleScheduledRestDayClash = [
+    {
+      timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
+      startTime: '2022-11-07T00:00:00.000+00:00',
+      endTime: '2022-11-08T00:00:00.000+00:00',
+    },
+  ];
+
+  describe('Clashing properties', () => {
+    it('should display a single error for start time clash', () => {
+      render(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={singleShiftClash}
+        />
+      );
+
+      const clashingShiftError = screen.getByText(
+        'Your start time must not overlap with another time period'
+      );
+      expect(clashingShiftError).toBeTruthy();
+    });
+
+    it('should display a single error for finish time clash', () => {
+      render(
+        <TimeInputErrors
+          clashingProperty={'endTime'}
+          clashes={singleShiftClash}
+        />
+      );
+
+      const clashingShiftError = screen.getByText(
+        'Your finish time must not overlap with another time period'
+      );
+      expect(clashingShiftError).toBeTruthy();
+    });
+
+    it('should display a single error for start and finish time clash', () => {
+      render(
+        <TimeInputErrors
+          clashingProperty={'startAndEndTime'}
+          clashes={singleShiftClash}
+        />
+      );
+
+      const clashingShiftError = screen.getByText(
+        'Your start and finish times must not overlap with another time period'
+      );
+      expect(clashingShiftError).toBeTruthy();
+    });
   });
 
-  it('should display a single error for finish time clash', () => {
-    render(<TimeInputErrors clashingProperty={'endTime'} />);
+  describe('Single time clashes', () => {
+    it('should display a single error for shift clash', () => {
+      render(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={singleShiftClash}
+        />
+      );
 
-    const clashingShiftError = screen.getByText(
-      'Your finish time must not overlap with another time period'
-    );
-    expect(clashingShiftError).toBeTruthy();
-  });
+      const clashingShiftError = screen.getByText(
+        'You are already assigned to work from 08:00 to 12:00 on 2022-11-07'
+      );
+      expect(clashingShiftError).toBeTruthy();
+    });
 
-  it('should display a single error for start and finish time clash', () => {
-    render(<TimeInputErrors clashingProperty={'startAndEndTime'} />);
+    it('should display a single error for scheduled rest day clash', () => {
+      render(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={singleScheduledRestDayClash}
+        />
+      );
 
-    const clashingShiftError = screen.getByText(
-      'Your start and finish times must not overlap with another time period'
-    );
-    expect(clashingShiftError).toBeTruthy();
+      const clashingShiftError = screen.getByText(
+        'You are already assigned a scheduled rest day on 2022-11-07'
+      );
+      expect(clashingShiftError).toBeTruthy();
+    });
   });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import TimeInputErrors from './TimeInputErrors';
+
+describe('TimeInputErrors', () => {
+  it('should display a single error for start time clash', () => {
+    render(<TimeInputErrors clashingProperty={'startTime'} />);
+
+    const clashingShiftError = screen.getByText(
+      'Your start time must not overlap with another time period'
+    );
+    expect(clashingShiftError).toBeTruthy();
+  });
+
+  it('should display a single error for finish time clash', () => {
+    render(<TimeInputErrors clashingProperty={'endTime'} />);
+
+    const clashingShiftError = screen.getByText(
+      'Your finish time must not overlap with another time period'
+    );
+    expect(clashingShiftError).toBeTruthy();
+  });
+
+  it('should display a single error for start and finish time clash', () => {
+    render(<TimeInputErrors clashingProperty={'startAndEndTime'} />);
+
+    const clashingShiftError = screen.getByText(
+      'Your start and finish times must not overlap with another time period'
+    );
+    expect(clashingShiftError).toBeTruthy();
+  });
+});

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -1,26 +1,48 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithTimecardContext } from '../../../test/helpers/TimecardContext';
 import TimeInputErrors from './TimeInputErrors';
 
 describe('TimeInputErrors', () => {
   const singleShiftClash = [
     {
       timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
-      startTime: '2022-11-07T08:00:00.000+00:00',
-      endTime: '2022-11-07T12:00:00.000+00:00',
+      startTime: '2022-11-03T08:00:00.000+00:00',
+      endTime: '2022-11-03T12:00:00.000+00:00',
     },
   ];
 
   const singleScheduledRestDayClash = [
     {
       timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
-      startTime: '2022-11-07T00:00:00.000+00:00',
-      endTime: '2022-11-08T00:00:00.000+00:00',
+      startTime: '2022-11-03T00:00:00.000+00:00',
+      endTime: '2022-11-04T00:00:00.000+00:00',
+    },
+  ];
+
+  const singleNonWorkingDayClash = [
+    {
+      timePeriodTypeId: '00000000-0000-0000-0000-000000000003',
+      startTime: '2022-11-03T00:00:00.000+00:00',
+      endTime: '2022-11-04T00:00:00.000+00:00',
+    },
+  ];
+
+  const twoShiftClashes = [
+    {
+      timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+      startTime: '2022-11-03T08:00:00.000+00:00',
+      endTime: '2022-11-03T12:00:00.000+00:00',
+    },
+    {
+      timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+      startTime: '2022-11-03T17:00:00.000+00:00',
+      endTime: '2022-11-03T18:00:00.000+00:00',
     },
   ];
 
   describe('Clashing properties', () => {
     it('should display a single error for start time clash', () => {
-      render(
+      renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startTime'}
           clashes={singleShiftClash}
@@ -34,7 +56,7 @@ describe('TimeInputErrors', () => {
     });
 
     it('should display a single error for finish time clash', () => {
-      render(
+      renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'endTime'}
           clashes={singleShiftClash}
@@ -48,7 +70,7 @@ describe('TimeInputErrors', () => {
     });
 
     it('should display a single error for start and finish time clash', () => {
-      render(
+      renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startAndEndTime'}
           clashes={singleShiftClash}
@@ -64,7 +86,7 @@ describe('TimeInputErrors', () => {
 
   describe('Single time clashes', () => {
     it('should display a single error for shift clash', () => {
-      render(
+      renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startTime'}
           clashes={singleShiftClash}
@@ -72,13 +94,13 @@ describe('TimeInputErrors', () => {
       );
 
       const clashingShiftError = screen.getByText(
-        'You are already assigned to work from 08:00 to 12:00 on 2022-11-07'
+        'You are already assigned to work from 08:00 to 12:00 on 3 November 2022'
       );
       expect(clashingShiftError).toBeTruthy();
     });
 
-    it('should display a single error for scheduled rest day clash test', () => {
-      render(
+    it('should display a single error for scheduled rest day clash', () => {
+      renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startTime'}
           clashes={singleScheduledRestDayClash}
@@ -86,9 +108,49 @@ describe('TimeInputErrors', () => {
       );
 
       const clashingShiftError = screen.getByText(
-        'You are already assigned a scheduled rest day on 2022-11-07'
+        'You are already assigned a scheduled rest day on 3 November 2022'
       );
       expect(clashingShiftError).toBeTruthy();
+    });
+
+    it('should display a single error for non-working day clash', () => {
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={singleNonWorkingDayClash}
+        />
+      );
+
+      const clashingShiftError = screen.getByText(
+        'You are already assigned a non-working day on 3 November 2022'
+      );
+      expect(clashingShiftError).toBeTruthy();
+    });
+  });
+
+  describe('Multiple time clashes', () => {
+    it('should display both errors for two shift clashes', () => {
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={twoShiftClashes}
+        />
+      );
+
+      const clashingShiftError = screen.getByText(
+        'You are already assigned to the following time periods:'
+      );
+      expect(clashingShiftError).toBeTruthy();
+
+      const clashingShiftError1 = screen.getByText(
+        '08:00 to 12:00 on 3 November 2022'
+      );
+      expect(clashingShiftError1).toBeTruthy();
+
+      const clashingShiftError2 = screen.getByText(
+        '17:00 to 18:00 on 3 November 2022'
+      );
+      expect(clashingShiftError2).toBeTruthy();
     });
   });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -356,4 +356,19 @@ describe('TimeInputErrors', () => {
       expect(secondClashingShiftError).toBeTruthy();
     });
   });
+
+  describe('Invalid input', () => {
+    it('should throw an error if no clashes are given', () => {
+      expect(() =>
+        renderWithTimecardContext(
+          <TimeInputErrors
+            clashingProperty={clashingProperties.startTime}
+            clashes={[]}
+          />
+        )
+      ).toThrow(
+        'The time clashes data did not contain at least one time clash.'
+      );
+    });
+  });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -11,35 +11,6 @@ describe('TimeInputErrors', () => {
     },
   ];
 
-  const singleScheduledRestDayClash = [
-    {
-      timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
-      startTime: '2022-11-03T00:00:00.000+00:00',
-      endTime: '2022-11-04T00:00:00.000+00:00',
-    },
-  ];
-
-  const singleNonWorkingDayClash = [
-    {
-      timePeriodTypeId: '00000000-0000-0000-0000-000000000003',
-      startTime: '2022-11-03T00:00:00.000+00:00',
-      endTime: '2022-11-04T00:00:00.000+00:00',
-    },
-  ];
-
-  const twoShiftClashes = [
-    {
-      timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
-      startTime: '2022-11-03T08:00:00.000+00:00',
-      endTime: '2022-11-03T12:00:00.000+00:00',
-    },
-    {
-      timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
-      startTime: '2022-11-03T17:00:00.000+00:00',
-      endTime: '2022-11-03T18:00:00.000+00:00',
-    },
-  ];
-
   describe('Clashing properties', () => {
     it('should display a single error for start time clash', () => {
       renderWithTimecardContext(
@@ -100,6 +71,14 @@ describe('TimeInputErrors', () => {
     });
 
     it('should display a single error for scheduled rest day clash', () => {
+      const singleScheduledRestDayClash = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
+          startTime: '2022-11-03T00:00:00.000+00:00',
+          endTime: '2022-11-04T00:00:00.000+00:00',
+        },
+      ];
+
       renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startTime'}
@@ -114,6 +93,14 @@ describe('TimeInputErrors', () => {
     });
 
     it('should display a single error for non-working day clash', () => {
+      const singleNonWorkingDayClash = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000003',
+          startTime: '2022-11-03T00:00:00.000+00:00',
+          endTime: '2022-11-04T00:00:00.000+00:00',
+        },
+      ];
+
       renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startTime'}
@@ -130,6 +117,19 @@ describe('TimeInputErrors', () => {
 
   describe('Multiple time clashes', () => {
     it('should display both errors for two shift clashes', () => {
+      const twoShiftClashes = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T08:00:00.000+00:00',
+          endTime: '2022-11-03T12:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T17:00:00.000+00:00',
+          endTime: '2022-11-03T18:00:00.000+00:00',
+        },
+      ];
+
       renderWithTimecardContext(
         <TimeInputErrors
           clashingProperty={'startTime'}
@@ -140,17 +140,88 @@ describe('TimeInputErrors', () => {
       const clashingShiftError = screen.getByText(
         'You are already assigned to the following time periods:'
       );
-      expect(clashingShiftError).toBeTruthy();
-
-      const clashingShiftError1 = screen.getByText(
+      const firstClashingShift = screen.getByText(
         '08:00 to 12:00 on 3 November 2022'
       );
-      expect(clashingShiftError1).toBeTruthy();
-
-      const clashingShiftError2 = screen.getByText(
+      const secondClashingShift = screen.getByText(
         '17:00 to 18:00 on 3 November 2022'
       );
-      expect(clashingShiftError2).toBeTruthy();
+
+      expect(clashingShiftError).toBeTruthy();
+      expect(firstClashingShift).toBeTruthy();
+      expect(secondClashingShift).toBeTruthy();
+    });
+
+    it('should display both errors for SRD and shift clashes', () => {
+      const shiftAndSRDClashes = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T08:00:00.000+00:00',
+          endTime: '2022-11-03T12:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
+          startTime: '2022-11-04T00:00:00.000+00:00',
+          endTime: '2022-11-05T00:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={shiftAndSRDClashes}
+        />
+      );
+
+      const clashingTimePeriodError = screen.getByText(
+        'You are already assigned to the following time periods:'
+      );
+      const clashingShift = screen.getByText(
+        '08:00 to 12:00 on 3 November 2022'
+      );
+      const clashingSRD = screen.getByText(
+        'scheduled rest day on 4 November 2022'
+      );
+
+      expect(clashingTimePeriodError).toBeTruthy();
+      expect(clashingShift).toBeTruthy();
+      expect(clashingSRD).toBeTruthy();
+    });
+
+    it('should display both errors for SRD and NWD clashes', () => {
+      const shiftAndSRDClashes = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000003',
+          startTime: '2022-11-03T00:00:00.000+00:00',
+          endTime: '2022-11-04T00:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000002',
+          startTime: '2022-11-04T00:00:00.000+00:00',
+          endTime: '2022-11-05T00:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={shiftAndSRDClashes}
+        />
+      );
+
+      const clashingTimePeriodError = screen.getByText(
+        'You are already assigned to the following time periods:'
+      );
+      const clashingNWD = screen.getByText(
+        'non-working day on 3 November 2022'
+      );
+      const clashingSRD = screen.getByText(
+        'scheduled rest day on 4 November 2022'
+      );
+
+      expect(clashingTimePeriodError).toBeTruthy();
+      expect(clashingNWD).toBeTruthy();
+      expect(clashingSRD).toBeTruthy();
     });
   });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -264,6 +264,39 @@ describe('TimeInputErrors', () => {
         '12:00 on 4 November 2022 to 16:00 on 5 November 2022'
       );
     });
+
+    it('should display time clashes in chronological order by start time and date', () => {
+      const shiftAndSRDClashes = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T09:00:00.000+00:00',
+          endTime: '2022-11-04T16:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-04T08:00:00.000+00:00',
+          endTime: '2022-11-04T12:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={shiftAndSRDClashes}
+        />
+      );
+
+      const clashingTimePeriods = screen
+        .getAllByTestId('test')
+        .map(getNodeText);
+
+      expect(clashingTimePeriods[0]).toEqual(
+        '09:00 on 3 November 2022 to 16:00 on 4 November 2022'
+      );
+      expect(clashingTimePeriods[1]).toEqual(
+        '08:00 to 12:00 on 4 November 2022'
+      );
+    });
   });
 
   describe('Clash finishes on a different day', () => {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -265,4 +265,28 @@ describe('TimeInputErrors', () => {
       );
     });
   });
+  describe('Clash finishes on a different day', () => {
+    it('should display both days for a single shift clash that is over two days', () => {
+      const twoShiftClashes = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T08:00:00.000+00:00',
+          endTime: '2022-11-04T12:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={'startTime'}
+          clashes={twoShiftClashes}
+        />
+      );
+
+      const clashingShiftError = screen.getByText(
+        'You are already assigned to work from 08:00 on 3 November 2022 to 12:00 on 4 November 2022'
+      );
+
+      expect(clashingShiftError).toBeTruthy();
+    });
+  });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -239,7 +239,7 @@ describe('TimeInputErrors', () => {
         {
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
           startTime: '2022-11-04T08:00:00.000+00:00',
-          endTime: '2022-11-05T12:00:00.000+00:00',
+          endTime: '2022-11-04T12:00:00.000+00:00',
         },
       ];
 
@@ -261,13 +261,14 @@ describe('TimeInputErrors', () => {
         '08:00 to 12:00 on 4 November 2022'
       );
       expect(clashingTimePeriods[2]).toEqual(
-        '12:00 to 16:00 on 4 November 2022'
+        '12:00 on 4 November 2022 to 16:00 on 5 November 2022'
       );
     });
   });
+
   describe('Clash finishes on a different day', () => {
     it('should display both days for a single shift clash that is over two days', () => {
-      const twoShiftClashes = [
+      const shiftClash = [
         {
           timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
           startTime: '2022-11-03T08:00:00.000+00:00',
@@ -276,10 +277,7 @@ describe('TimeInputErrors', () => {
       ];
 
       renderWithTimecardContext(
-        <TimeInputErrors
-          clashingProperty={'startTime'}
-          clashes={twoShiftClashes}
-        />
+        <TimeInputErrors clashingProperty={'startTime'} clashes={shiftClash} />
       );
 
       const clashingShiftError = screen.getByText(
@@ -287,6 +285,35 @@ describe('TimeInputErrors', () => {
       );
 
       expect(clashingShiftError).toBeTruthy();
+    });
+
+    it('should display both days for two shift clashes that are over two days', () => {
+      const shiftClash = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T08:00:00.000+00:00',
+          endTime: '2022-11-04T12:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-04T07:00:00.000+00:00',
+          endTime: '2022-11-05T11:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors clashingProperty={'startTime'} clashes={shiftClash} />
+      );
+
+      const firstClashingShiftError = screen.getByText(
+        '08:00 on 3 November 2022 to 12:00 on 4 November 2022'
+      );
+      const secondClashingShiftError = screen.getByText(
+        '07:00 on 4 November 2022 to 11:00 on 5 November 2022'
+      );
+
+      expect(firstClashingShiftError).toBeTruthy();
+      expect(secondClashingShiftError).toBeTruthy();
     });
   });
 });

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -77,7 +77,7 @@ describe('TimeInputErrors', () => {
       expect(clashingShiftError).toBeTruthy();
     });
 
-    it('should display a single error for scheduled rest day clash', () => {
+    it('should display a single error for scheduled rest day clash test', () => {
       render(
         <TimeInputErrors
           clashingProperty={'startTime'}

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -12,6 +12,7 @@ import {
   getTimePeriodTypesMap,
   formatTime,
   isFinishTimeOnNextDay,
+  inputNames,
 } from '../../utils/time-entry-utils/timeEntryUtils';
 import { UrlSearchParamBuilder } from '../../utils/api-utils/UrlSearchParamBuilder';
 import { validateServiceErrors } from '../../utils/api-utils/ApiUtils';
@@ -42,8 +43,8 @@ const Timecard = () => {
   const nextDay = formatDate(dayjs(date).add(1, 'day'));
 
   const desiredErrorOrder = [
-    'shift-start-time',
-    'shift-finish-time',
+    inputNames.shiftStartTime,
+    inputNames.shiftFinishTime,
     'timePeriod',
   ];
 

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -10,6 +10,7 @@ import { getTimeEntries } from '../../api/services/timecardService';
 import {
   formatTime,
   formatDate,
+  getTimePeriodTypesMap,
 } from '../../utils/time-entry-utils/timeEntryUtils';
 import { UrlSearchParamBuilder } from '../../utils/api-utils/UrlSearchParamBuilder';
 import { validateServiceErrors } from '../../utils/api-utils/ApiUtils';
@@ -161,13 +162,6 @@ const updateTimeEntryContextData = async (
     },
     handleCustomErrors,
     false
-  );
-};
-
-const getTimePeriodTypesMap = (timePeriodTypes) => {
-  return timePeriodTypes.reduce(
-    (acc, type) => ({ ...acc, [type.id]: type.name }),
-    {}
   );
 };
 

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -137,8 +137,6 @@ const updateTimeEntryContextData = async (
     .setFilters("ownerId=='" + userId + "'", ...filterTimeEntriesOnDate(date))
     .getUrlSearchParams();
 
-  const handleCustomErrors = () => {};
-
   validateServiceErrors(
     setServiceError,
     async () => {
@@ -166,7 +164,6 @@ const updateTimeEntryContextData = async (
         setTimeEntries([]);
       }
     },
-    handleCustomErrors,
     false
   );
 };

--- a/src/pages/timecard/Timecard.jsx
+++ b/src/pages/timecard/Timecard.jsx
@@ -12,7 +12,6 @@ import {
   getTimePeriodTypesMap,
   formatTime,
   isFinishTimeOnNextDay,
-  inputNames,
 } from '../../utils/time-entry-utils/timeEntryUtils';
 import { UrlSearchParamBuilder } from '../../utils/api-utils/UrlSearchParamBuilder';
 import { validateServiceErrors } from '../../utils/api-utils/ApiUtils';
@@ -25,6 +24,7 @@ import { buildTimeEntriesFilter } from '../../utils/filters/time-entry-filter/ti
 import { ContextTimeEntry } from '../../utils/time-entry-utils/ContextTimeEntry';
 import SimpleTimePeriod from '../../components/timecard/simple-time-period/SimpleTimePeriod';
 import AddTimeCardPeriod from '../../components/timecard/add-timecard-period/AddTimeCardPeriod';
+import { inputNames } from '../../utils/constants';
 
 const Timecard = () => {
   const {

--- a/src/utils/api-utils/ApiUtils.js
+++ b/src/utils/api-utils/ApiUtils.js
@@ -11,7 +11,6 @@ export const validateServiceErrors = async (
     });
   } catch (error) {
     console.error(error);
-    console.log(error?.response?.data);
     const allErrorsHandled = handleCustomErrors(error?.response?.data);
 
     if (allErrorsHandled) {

--- a/src/utils/api-utils/ApiUtils.js
+++ b/src/utils/api-utils/ApiUtils.js
@@ -1,8 +1,8 @@
 export const validateServiceErrors = async (
   setServiceError,
   serviceFunction,
-  handleCustomErrors = () => {},
-  isRecoverable = true
+  isRecoverable = true,
+  handleCustomErrors = () => {}
 ) => {
   try {
     await serviceFunction();

--- a/src/utils/api-utils/ApiUtils.js
+++ b/src/utils/api-utils/ApiUtils.js
@@ -11,7 +11,8 @@ export const validateServiceErrors = async (
     });
   } catch (error) {
     console.error(error);
-    const allErrorsHandled = handleCustomErrors(error?.response?.data?.message);
+    console.log(error?.response?.data);
+    const allErrorsHandled = handleCustomErrors(error?.response?.data);
 
     if (allErrorsHandled) {
       setServiceError({

--- a/src/utils/api-utils/ApiUtils.spec.js
+++ b/src/utils/api-utils/ApiUtils.spec.js
@@ -48,7 +48,7 @@ describe('ApiUtils', () => {
     const serviceFunction = () => {
       throw new Error();
     };
-    validateServiceErrors(setServiceError, serviceFunction, () => {}, false);
+    validateServiceErrors(setServiceError, serviceFunction, false, () => {});
 
     await waitFor(() => {
       expect(setServiceError).toHaveBeenCalledWith({
@@ -77,6 +77,7 @@ describe('ApiUtils', () => {
       validateServiceErrors(
         setServiceError,
         serviceFunction,
+        true,
         handleCustomErrors
       );
 
@@ -104,6 +105,7 @@ describe('ApiUtils', () => {
       validateServiceErrors(
         setServiceError,
         serviceFunction,
+        true,
         handleCustomErrors
       );
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,10 @@
+export const ClashingProperty = {
+  startTime: 'startTime',
+  endTime: 'endTime',
+  startAndEndTime: 'startAndEndTime',
+};
+
+export const inputNames = {
+  shiftStartTime: 'shift-start-time',
+  shiftFinishTime: 'shift-finish-time',
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
-export const ClashingProperty = {
+export const clashingProperties = {
   startTime: 'startTime',
   endTime: 'endTime',
   startAndEndTime: 'startAndEndTime',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,10 +1,10 @@
-export const clashingProperties = {
+export const clashingProperties = Object.freeze({
   startTime: 'startTime',
   endTime: 'endTime',
   startAndEndTime: 'startAndEndTime',
-};
+});
 
-export const inputNames = {
+export const inputNames = Object.freeze({
   shiftStartTime: 'shift-start-time',
   shiftFinishTime: 'shift-finish-time',
-};
+});

--- a/src/utils/sort-errors/sortErrors.js
+++ b/src/utils/sort-errors/sortErrors.js
@@ -1,5 +1,5 @@
 export const sortErrorKeys = (errors, desiredOrder) => {
-  var orderedKeys = [];
+  const orderedKeys = [];
   const errorKeys = new Set(Object.keys(errors));
   desiredOrder.forEach((key) => {
     if (errorKeys.has(key)) {

--- a/src/utils/time-entry-utils/combineTimeErrors.jsx
+++ b/src/utils/time-entry-utils/combineTimeErrors.jsx
@@ -13,36 +13,35 @@ export function combineExistingAndTimeClashErrors(
   const combinedErrors = { ...existingErrors };
 
   if (clashingProperty === clashingProperties.startAndEndTime) {
-    combinedErrors[inputNames.shiftStartTime] = {
-      message: (
-        <TimeInputErrors
-          clashingProperty={clashingProperty}
-          clashes={clashingTimes}
-        />
-      ),
-    };
+    combinedErrors[inputNames.shiftStartTime] = clashErrorMessage(
+      clashingProperty,
+      clashingTimes
+    );
     combinedErrors[inputNames.shiftFinishTime] = {
       message: '',
     };
   } else if (clashingProperty === clashingProperties.startTime) {
-    combinedErrors[inputNames.shiftStartTime] = {
-      message: (
-        <TimeInputErrors
-          clashingProperty={clashingProperty}
-          clashes={clashingTimes}
-        />
-      ),
-    };
+    combinedErrors[inputNames.shiftStartTime] = clashErrorMessage(
+      clashingProperty,
+      clashingTimes
+    );
   } else if (clashingProperty === clashingProperties.endTime) {
-    combinedErrors[inputNames.shiftFinishTime] = {
-      message: (
-        <TimeInputErrors
-          clashingProperty={clashingProperty}
-          clashes={clashingTimes}
-        />
-      ),
-    };
+    combinedErrors[inputNames.shiftFinishTime] = clashErrorMessage(
+      clashingProperty,
+      clashingTimes
+    );
   }
 
   return combinedErrors;
+}
+
+function clashErrorMessage(clashingProperty, clashingTimes) {
+  return {
+    message: (
+      <TimeInputErrors
+        clashingProperty={clashingProperty}
+        clashes={clashingTimes}
+      />
+    ),
+  };
 }

--- a/src/utils/time-entry-utils/combineTimeErrors.jsx
+++ b/src/utils/time-entry-utils/combineTimeErrors.jsx
@@ -1,0 +1,48 @@
+import TimeInputErrors from "../../components/timecard/time-input-errors/TimeInputErrors";
+import { clashingProperties, inputNames } from "../constants";
+
+export function combineExistingAndTimeClashErrors(
+  errors,
+  summaryErrors,
+  clashingProperty,
+  clashingTimes
+) {
+  const existingErrors =
+    Object.keys(errors).length > 0 ? errors : summaryErrors;
+
+  const combinedErrors = { ...existingErrors };
+
+  if (clashingProperty === clashingProperties.startAndEndTime) {
+    combinedErrors[inputNames.shiftStartTime] = {
+      message: (
+        <TimeInputErrors
+          clashingProperty={clashingProperty}
+          clashes={clashingTimes}
+        />
+      ),
+    };
+    combinedErrors[inputNames.shiftFinishTime] = {
+      message: '',
+    };
+  } else if (clashingProperty === clashingProperties.startTime) {
+    combinedErrors[inputNames.shiftStartTime] = {
+      message: (
+        <TimeInputErrors
+          clashingProperty={clashingProperty}
+          clashes={clashingTimes}
+        />
+      ),
+    };
+  } else if (clashingProperty === clashingProperties.endTime) {
+    combinedErrors[inputNames.shiftFinishTime] = {
+      message: (
+        <TimeInputErrors
+          clashingProperty={clashingProperty}
+          clashes={clashingTimes}
+        />
+      ),
+    };
+  }
+
+  return combinedErrors;
+}

--- a/src/utils/time-entry-utils/combineTimeErrors.jsx
+++ b/src/utils/time-entry-utils/combineTimeErrors.jsx
@@ -1,5 +1,5 @@
-import TimeInputErrors from "../../components/timecard/time-input-errors/TimeInputErrors";
-import { clashingProperties, inputNames } from "../constants";
+import TimeInputErrors from '../../components/timecard/time-input-errors/TimeInputErrors';
+import { clashingProperties, inputNames } from '../constants';
 
 export function combineExistingAndTimeClashErrors(
   errors,

--- a/src/utils/time-entry-utils/combineTimeErrors.spec.jsx
+++ b/src/utils/time-entry-utils/combineTimeErrors.spec.jsx
@@ -1,0 +1,86 @@
+import TimeInputErrors from '../../components/timecard/time-input-errors/TimeInputErrors';
+import { clashingProperties, inputNames } from '../constants';
+import { combineExistingAndTimeClashErrors } from './combineTimeErrors';
+
+describe('combineExistingAndTimeClashErrors', () => {
+  it('should return an empty array when no errors are passed in', async () => {
+    var result = combineExistingAndTimeClashErrors({}, {}, null, null);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return only the original errors when no time clash errors are passed in', async () => {
+    var result = combineExistingAndTimeClashErrors(
+      { foo: 'bar' },
+      {},
+      null,
+      null
+    );
+
+    expect(result).toEqual({ foo: 'bar' });
+  });
+
+  it('should add a start time error when start time is the clashing property', async () => {
+    var expectedClashMessage = (
+      <TimeInputErrors
+        clashes={[]}
+        clashingProperty={clashingProperties.startTime}
+      />
+    );
+
+    var result = combineExistingAndTimeClashErrors(
+      { foo: 'bar' },
+      {},
+      clashingProperties.startTime,
+      []
+    );
+
+    expect(result).toEqual({
+      foo: 'bar',
+      [inputNames.shiftStartTime]: { message: expectedClashMessage },
+    });
+  });
+
+  it('should add a finish time error when finish time is the clashing property', async () => {
+    var expectedClashMessage = (
+      <TimeInputErrors
+        clashes={[]}
+        clashingProperty={clashingProperties.endTime}
+      />
+    );
+
+    var result = combineExistingAndTimeClashErrors(
+      { foo: 'bar' },
+      {},
+      clashingProperties.endTime,
+      []
+    );
+
+    expect(result).toEqual({
+      foo: 'bar',
+      [inputNames.shiftFinishTime]: { message: expectedClashMessage },
+    });
+  });
+
+  it('should add a start and end time error when start and end time time is the clashing property', async () => {
+    var expectedClashMessage = (
+      <TimeInputErrors
+        clashes={[]}
+        clashingProperty={clashingProperties.startAndEndTime}
+      />
+    );
+
+    var result = combineExistingAndTimeClashErrors(
+      { foo: 'bar' },
+      {},
+      clashingProperties.startAndEndTime,
+      []
+    );
+
+    expect(result).toEqual({
+      foo: 'bar',
+      [inputNames.shiftStartTime]: { message: expectedClashMessage },
+      [inputNames.shiftFinishTime]: { message: '' },
+    });
+  });
+});

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -59,14 +59,3 @@ export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   }
   return false;
 };
-
-export const ClashingProperty = {
-  startTime: 'startTime',
-  endTime: 'endTime',
-  startAndEndTime: 'startAndEndTime',
-};
-
-export const inputNames = {
-  shiftStartTime: 'shift-start-time',
-  shiftFinishTime: 'shift-finish-time',
-};

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -1,8 +1,6 @@
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import TimeInputErrors from '../../components/timecard/time-input-errors/TimeInputErrors';
 import { deepCloneJson } from '../common-utils/common-utils';
-import { clashingProperties, inputNames } from '../constants';
 
 dayjs.extend(isSameOrBefore);
 
@@ -61,49 +59,3 @@ export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   }
   return false;
 };
-
-export function combineExistingAndTimeClashErrors(
-  errors,
-  summaryErrors,
-  clashingProperty,
-  clashingTimes
-) {
-  const existingErrors =
-    Object.keys(errors).length > 0 ? errors : summaryErrors;
-
-  const combinedErrors = { ...existingErrors };
-
-  if (clashingProperty === clashingProperties.startAndEndTime) {
-    combinedErrors[inputNames.shiftStartTime] = {
-      message: (
-        <TimeInputErrors
-          clashingProperty={clashingProperty}
-          clashes={clashingTimes}
-        />
-      ),
-    };
-    combinedErrors[inputNames.shiftFinishTime] = {
-      message: '',
-    };
-  } else if (clashingProperty === clashingProperties.startTime) {
-    combinedErrors[inputNames.shiftStartTime] = {
-      message: (
-        <TimeInputErrors
-          clashingProperty={clashingProperty}
-          clashes={clashingTimes}
-        />
-      ),
-    };
-  } else if (clashingProperty === clashingProperties.endTime) {
-    combinedErrors[inputNames.shiftFinishTime] = {
-      message: (
-        <TimeInputErrors
-          clashingProperty={clashingProperty}
-          clashes={clashingTimes}
-        />
-      ),
-    };
-  }
-
-  return combinedErrors;
-}

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import TimeInputErrors from '../../components/timecard/time-input-errors/TimeInputErrors';
 import { deepCloneJson } from '../common-utils/common-utils';
+import { clashingProperties, inputNames } from '../constants';
 
 dayjs.extend(isSameOrBefore);
 
@@ -59,3 +61,49 @@ export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   }
   return false;
 };
+
+export function combineExistingAndTimeClashErrors(
+  errors,
+  summaryErrors,
+  clashingProperty,
+  clashingTimes
+) {
+  const existingErrors =
+    Object.keys(errors).length > 0 ? errors : summaryErrors;
+
+  const combinedErrors = { ...existingErrors };
+
+  if (clashingProperty === clashingProperties.startAndEndTime) {
+    combinedErrors[inputNames.shiftStartTime] = {
+      message: (
+        <TimeInputErrors
+          clashingProperty={clashingProperty}
+          clashes={clashingTimes}
+        />
+      ),
+    };
+    combinedErrors[inputNames.shiftFinishTime] = {
+      message: '',
+    };
+  } else if (clashingProperty === clashingProperties.startTime) {
+    combinedErrors[inputNames.shiftStartTime] = {
+      message: (
+        <TimeInputErrors
+          clashingProperty={clashingProperty}
+          clashes={clashingTimes}
+        />
+      ),
+    };
+  } else if (clashingProperty === clashingProperties.endTime) {
+    combinedErrors[inputNames.shiftFinishTime] = {
+      message: (
+        <TimeInputErrors
+          clashingProperty={clashingProperty}
+          clashes={clashingTimes}
+        />
+      ),
+    };
+  }
+
+  return combinedErrors;
+}

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -59,3 +59,14 @@ export const isFinishTimeOnNextDay = (startTimeValue, finishTimeValue) => {
   }
   return false;
 };
+
+export const ClashingProperty = {
+  startTime: 'startTime',
+  endTime: 'endTime',
+  startAndEndTime: 'startAndEndTime',
+};
+
+export const inputNames = {
+  shiftStartTime: 'shift-start-time',
+  shiftFinishTime: 'shift-finish-time',
+};

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -32,3 +32,10 @@ export const removeTimecardContextEntry = (
   newTimeEntries.splice(removeAtIndex, 1);
   setTimeEntries(newTimeEntries);
 };
+
+export const getTimePeriodTypesMap = (timePeriodTypes) => {
+  return timePeriodTypes.reduce(
+    (acc, type) => ({ ...acc, [type.id]: type.name }),
+    {}
+  );
+};

--- a/src/utils/time-entry-utils/timeEntryUtils.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.js
@@ -30,6 +30,10 @@ export const formatDateTimeISO = (dateTime) => {
   return dayjs(dateTime).format('YYYY-MM-DDTHH:mm:ssZ');
 };
 
+export const formatLongDate = (dateTime) => {
+  return dayjs(dateTime).format('D MMMM YYYY');
+};
+
 export const removeTimecardContextEntry = (
   timeEntries,
   setTimeEntries,

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -1,8 +1,11 @@
+import TimeInputErrors from '../../components/timecard/time-input-errors/TimeInputErrors';
+import { clashingProperties, inputNames } from '../constants';
 import { ContextTimeEntry } from './ContextTimeEntry';
 import {
   isFinishTimeOnNextDay,
   getSingleTimeEntryResponseItem,
   removeTimecardContextEntry,
+  combineExistingAndTimeClashErrors,
 } from './timeEntryUtils';
 
 describe('timeEntryUtils', () => {
@@ -86,6 +89,89 @@ describe('timeEntryUtils', () => {
       const finishTime = '';
 
       expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeFalsy();
+    });
+  });
+
+  describe('combineExistingAndTimeClashErrors', () => {
+    it('should return an empty array when no errors are passed in', async () => {
+      var result = combineExistingAndTimeClashErrors({}, {}, null, null);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return only the original errors when no time clash errors are passed in', async () => {
+      var result = combineExistingAndTimeClashErrors(
+        { foo: 'bar' },
+        {},
+        null,
+        null
+      );
+
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should add a start time error when start time is the clashing property', async () => {
+      var expectedClashMessage = (
+        <TimeInputErrors
+          clashes={[]}
+          clashingProperty={clashingProperties.startTime}
+        />
+      );
+
+      var result = combineExistingAndTimeClashErrors(
+        { foo: 'bar' },
+        {},
+        clashingProperties.startTime,
+        []
+      );
+
+      expect(result).toEqual({
+        foo: 'bar',
+        [inputNames.shiftStartTime]: { message: expectedClashMessage },
+      });
+    });
+
+    it('should add a finish time error when finish time is the clashing property', async () => {
+      var expectedClashMessage = (
+        <TimeInputErrors
+          clashes={[]}
+          clashingProperty={clashingProperties.endTime}
+        />
+      );
+
+      var result = combineExistingAndTimeClashErrors(
+        { foo: 'bar' },
+        {},
+        clashingProperties.endTime,
+        []
+      );
+
+      expect(result).toEqual({
+        foo: 'bar',
+        [inputNames.shiftFinishTime]: { message: expectedClashMessage },
+      });
+    });
+
+    it('should add a start and end time error when start and end time time is the clashing property', async () => {
+      var expectedClashMessage = (
+        <TimeInputErrors
+          clashes={[]}
+          clashingProperty={clashingProperties.startAndEndTime}
+        />
+      );
+
+      var result = combineExistingAndTimeClashErrors(
+        { foo: 'bar' },
+        {},
+        clashingProperties.startAndEndTime,
+        []
+      );
+
+      expect(result).toEqual({
+        foo: 'bar',
+        [inputNames.shiftStartTime]: { message: expectedClashMessage },
+        [inputNames.shiftFinishTime]: { message: '' },
+      });
     });
   });
 });

--- a/src/utils/time-entry-utils/timeEntryUtils.spec.js
+++ b/src/utils/time-entry-utils/timeEntryUtils.spec.js
@@ -1,11 +1,8 @@
-import TimeInputErrors from '../../components/timecard/time-input-errors/TimeInputErrors';
-import { clashingProperties, inputNames } from '../constants';
 import { ContextTimeEntry } from './ContextTimeEntry';
 import {
   isFinishTimeOnNextDay,
   getSingleTimeEntryResponseItem,
   removeTimecardContextEntry,
-  combineExistingAndTimeClashErrors,
 } from './timeEntryUtils';
 
 describe('timeEntryUtils', () => {
@@ -89,89 +86,6 @@ describe('timeEntryUtils', () => {
       const finishTime = '';
 
       expect(isFinishTimeOnNextDay(startTime, finishTime)).toBeFalsy();
-    });
-  });
-
-  describe('combineExistingAndTimeClashErrors', () => {
-    it('should return an empty array when no errors are passed in', async () => {
-      var result = combineExistingAndTimeClashErrors({}, {}, null, null);
-
-      expect(result).toEqual({});
-    });
-
-    it('should return only the original errors when no time clash errors are passed in', async () => {
-      var result = combineExistingAndTimeClashErrors(
-        { foo: 'bar' },
-        {},
-        null,
-        null
-      );
-
-      expect(result).toEqual({ foo: 'bar' });
-    });
-
-    it('should add a start time error when start time is the clashing property', async () => {
-      var expectedClashMessage = (
-        <TimeInputErrors
-          clashes={[]}
-          clashingProperty={clashingProperties.startTime}
-        />
-      );
-
-      var result = combineExistingAndTimeClashErrors(
-        { foo: 'bar' },
-        {},
-        clashingProperties.startTime,
-        []
-      );
-
-      expect(result).toEqual({
-        foo: 'bar',
-        [inputNames.shiftStartTime]: { message: expectedClashMessage },
-      });
-    });
-
-    it('should add a finish time error when finish time is the clashing property', async () => {
-      var expectedClashMessage = (
-        <TimeInputErrors
-          clashes={[]}
-          clashingProperty={clashingProperties.endTime}
-        />
-      );
-
-      var result = combineExistingAndTimeClashErrors(
-        { foo: 'bar' },
-        {},
-        clashingProperties.endTime,
-        []
-      );
-
-      expect(result).toEqual({
-        foo: 'bar',
-        [inputNames.shiftFinishTime]: { message: expectedClashMessage },
-      });
-    });
-
-    it('should add a start and end time error when start and end time time is the clashing property', async () => {
-      var expectedClashMessage = (
-        <TimeInputErrors
-          clashes={[]}
-          clashingProperty={clashingProperties.startAndEndTime}
-        />
-      );
-
-      var result = combineExistingAndTimeClashErrors(
-        { foo: 'bar' },
-        {},
-        clashingProperties.startAndEndTime,
-        []
-      );
-
-      expect(result).toEqual({
-        foo: 'bar',
-        [inputNames.shiftStartTime]: { message: expectedClashMessage },
-        [inputNames.shiftFinishTime]: { message: '' },
-      });
     });
   });
 });


### PR DESCRIPTION
Add details of clashing shifts into the displayed error. Only the error by the entry boxes displays the clashing errors, whilst the summary box at the top of the page displays the generic error.
![Screenshot 2022-11-09 at 15 25 45](https://user-images.githubusercontent.com/113997250/200870868-5ef4d698-4320-4e9b-8073-2eb2b2587864.png)
![Screenshot 2022-11-09 at 15 26 04](https://user-images.githubusercontent.com/113997250/200870877-6a20fe11-7379-4f0d-b5b6-73af92ba6356.png)
