### PR TITLE
Tech/revert filter change

### DIFF
--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
@@ -5,7 +5,7 @@ import {
 } from '../resource-filter-builder/resourceFilterBuilder';
 
 export const filterTimeEntriesOnDate = (date) => {
-  const startOfDateFilter = filterOnOrAfterDate('actualEndTime', date);
+  const startOfDateFilter = filterOnOrAfterDate('actualStartTime', date);
   const endOfDateFilter = filterBeforeDate(
     'actualStartTime',
     dayjs(date).add(1, 'day')

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.spec.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.spec.js
@@ -10,7 +10,7 @@ describe('timeEntryFilterBuilder', () => {
       expect(filters).toHaveLength(2);
 
       // startOfDateFilter
-      expect(filters[0]).toContain('actualEndTime');
+      expect(filters[0]).toContain('actualStartTime');
       expect(filters[0]).toContain(date);
 
       // endOfDateFilter


### PR DESCRIPTION
This is a PR to revert the filter change Introduced as part of EAHW-589. A full fix for the requirement of showing time entry with an end date on the timecard date will be in another PR. This is to unblock test.