### PR TITLE
Eahw 589 update srd end time

### DIFF
--- a/src/components/timecard/simple-time-period/SimpleTimePeriod.jsx
+++ b/src/components/timecard/simple-time-period/SimpleTimePeriod.jsx
@@ -42,7 +42,7 @@ const SimpleTimePeriod = ({ timeEntry, timeEntriesIndex, timePeriodTitle }) => {
       dayjs(timecardDate).startOf('day')
     );
     const actualEndDateTime = formatDateTimeISO(
-      dayjs(timecardDate).startOf('day').add(1, 'day')
+      dayjs(timecardDate).endOf('day')
     );
 
     const timecardPayload = {

--- a/src/components/timecard/simple-time-period/SimpleTimePeriod.spec.jsx
+++ b/src/components/timecard/simple-time-period/SimpleTimePeriod.spec.jsx
@@ -10,7 +10,6 @@ import {
   deleteTimeEntry,
 } from '../../../api/services/timecardService';
 const timecardDate = '2022-09-01';
-const timecardDateNextDay = '2022-09-02';
 const midnight = '00:00';
 
 const newTimeEntry = {

--- a/src/components/timecard/simple-time-period/SimpleTimePeriod.spec.jsx
+++ b/src/components/timecard/simple-time-period/SimpleTimePeriod.spec.jsx
@@ -96,7 +96,7 @@ describe('SimpleTimePeriod', () => {
   describe('Save button', () => {
     it('should call createTimeEntry when pressing save', async () => {
       const expectedActualStartTime = `${timecardDate}T00:00:00+00:00`;
-      const expectedActualEndTime = `${timecardDateNextDay}T00:00:00+00:00`;
+      const expectedActualEndTime = `${timecardDate}T23:59:59+00:00`;
 
       const timecardService = require('../../../api/services/timecardService');
       const mockCreateTimeEntry = jest.spyOn(


### PR DESCRIPTION
This PR fixes a bug regarding SRD's. As we have had to update the filter to use EndTime. This had a knock on effect with SRD's as they were persisted as 00:00:00 the next day. This is has been updated to persist with 23:59:59.