### PR TITLE
add owner id to end time filter

### DIFF
--- a/mocks/mockData.js
+++ b/mocks/mockData.js
@@ -291,7 +291,7 @@ const shiftTimeCardPeriodType = {
 };
 
 const timeEntryFilter =
-  "ownerId=='00000000-0000-0000-0000-000000000000'&&actualStartTime>='20220-10-29T00:00:00+00:00'&&actualStartTime<='20220-10-29T23:59:00+00:00'||actualEndTime>='20220-10-29T00:00:00+00:00'&&actualEndTime<='20220-10-29T23:59:00+00:00'";
+  "ownerId=='00000000-0000-0000-0000-000000000000'&&actualStartTime>='20220-10-29T00:00:00+00:00'&&actualStartTime<='20220-10-29T23:59:00+00:00'||ownerId=='00000000-0000-0000-0000-000000000000'&&actualEndTime>='20220-10-29T00:00:00+00:00'&&actualEndTime<='20220-10-29T23:59:00+00:00'";
 
 module.exports = {
   shiftTimeEntry,

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
@@ -16,7 +16,7 @@ const filterTimeEntriesOnDate = (resourceDateProperty, date) => {
 };
 
 export const buildTimeEntriesFilter = (date, userId) => {
-  const ownerAndUserId = "ownerId=='" + userId + "'";
+  const ownerAndUserId = `ownerId=='${userId}'`;
 
   const startDateFilterCondition = joinAndConditions(
     ownerAndUserId,

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
@@ -16,13 +16,15 @@ const filterTimeEntriesOnDate = (resourceDateProperty, date) => {
 };
 
 export const buildTimeEntriesFilter = (date, userId) => {
+  const ownerAndUserId = "ownerId=='" + userId + "'";
+
   const startDateFilterCondition = joinAndConditions(
-    "ownerId=='" + userId + "'",
+    ownerAndUserId,
     ...filterTimeEntriesOnDate('actualStartTime', date)
   );
 
   const endDateFilterCondition = joinAndConditions(
-    "ownerId=='" + userId + "'",
+    ownerAndUserId,
     ...filterTimeEntriesOnDate('actualEndTime', date)
   );
 

--- a/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
+++ b/src/utils/filters/time-entry-filter/timeEntryFilterBuilder.js
@@ -17,10 +17,12 @@ const filterTimeEntriesOnDate = (resourceDateProperty, date) => {
 
 export const buildTimeEntriesFilter = (date, userId) => {
   const startDateFilterCondition = joinAndConditions(
+    "ownerId=='" + userId + "'",
     ...filterTimeEntriesOnDate('actualStartTime', date)
   );
 
   const endDateFilterCondition = joinAndConditions(
+    "ownerId=='" + userId + "'",
     ...filterTimeEntriesOnDate('actualEndTime', date)
   );
 
@@ -29,9 +31,5 @@ export const buildTimeEntriesFilter = (date, userId) => {
     endDateFilterCondition
   );
 
-  const timeCardFilter = joinAndConditions(
-    "ownerId=='" + userId + "'",
-    joinedStartEndDate
-  );
-  return timeCardFilter;
+  return joinedStartEndDate;
 };


### PR DESCRIPTION
Add owner id to the end time filter. Time periods could be seen by other users. By adding the owner id to the end time filter