### PR TITLE
Eahw 2337/promote prod

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -98,10 +98,11 @@ steps:
     when:
       event: 
         - push
-      # branch:
-      #   - main
+      branch:
+        - main
     depends_on:
       - build project
+      - sonar analysis      
   
   - name: upload to S3
     image: plugins/s3

--- a/.drone.yml
+++ b/.drone.yml
@@ -212,7 +212,7 @@ steps:
     settings:
       template: |
         {{#success build.status}}
-          Build #{{ build.number }} succeeded! :tada: {{#main build.branch}}and deployed to Dev{{/main}}
+          Build #{{ build.number }} succeeded {{#main build.branch}}and deployed to Dev{{/main}}! :tada:
         {{else}}
           Build #{{ build.number }} failed :alert:
         {{/success}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -271,7 +271,7 @@ steps:
         {{#success build.status}}
           :rocket: Successful *{{uppercasefirst build.deployTo}}* deployment for *{{repo.name}} build #{{build.number}}*.          
         {{else}}
-          :zombie: Problem *{{uppercasefirst build.deployTo}}* deployment failed for <${DRONE_BUILD_LINK}| build #{{build.number}}>.
+          :zombie: Problem *{{uppercasefirst build.deployTo}}* deployment failed for *{{repo.name}}* <${DRONE_BUILD_LINK}| build #{{build.number}}>.
         {{/success}}       
     when:
       event: 

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,11 +89,11 @@ steps:
     image: alpine/git
     commands:      
       - "git tag v$${DRONE_BUILD_NUMBER} && git push origin v$${DRONE_BUILD_NUMBER}"
-    when:
-      event: 
-        - push
-      branch:
-        - main
+    # when:
+    #   event: 
+    #     - push
+    #   branch:
+    #     - main
     depends_on:
       - build project
   

--- a/.drone.yml
+++ b/.drone.yml
@@ -153,7 +153,7 @@ steps:
       - npm ci
       - npm run build
 
-  - name: upload to S3
+  - name: upload to test S3
     image: plugins/s3
     settings:
       bucket: ho-callisto-dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -140,7 +140,7 @@ platform:
   arch: amd64
 
 depends_on:
-  - callisto-ui
+  - callisto-ui-dev-deploy
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -190,8 +190,6 @@ trigger:
   status:
     - success
     - failure
-  # event:
-  #   - push
 
 depends_on:
   - callisto-ui
@@ -212,7 +210,7 @@ steps:
     settings:
       template: |
         {{#success build.status}}
-          Build #{{ build.number }} succeeded! :tada:
+          Build #{{ build.number }} succeeded! :tada: {{#main build.branch}}and deployed to Dev{{/main}}
         {{else}}
           Build #{{ build.number }} failed :alert:
         {{/success}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,6 +85,25 @@ steps:
     depends_on:
       - install dependencies
 
+---
+kind: pipeline
+type: kubernetes
+name: callisto-ui-dev-deploy
+
+platform:
+  os: linux
+  arch: amd64
+
+depends_on:
+  - callisto-ui
+
+trigger:
+  event:
+    - push
+  branch:
+    - main  
+
+steps:
   - name: git tag push
     image: appleboy/drone-git-push
     settings:
@@ -94,15 +113,7 @@ steps:
         from_secret: github_private_key
       commit: true
       tag: v$${DRONE_BUILD_NUMBER}
-      followtags: true
-    when:
-      event: 
-        - push
-      branch:
-        - main
-    depends_on:
-      - build project
-      - sonar analysis      
+      followtags: true     
   
   - name: upload to S3
     image: plugins/s3
@@ -116,11 +127,6 @@ steps:
       source: dist/**/*
       strip_prefix: dist/
       target: dev/main
-    when:
-      event: 
-        - push
-      branch:
-        - main
     depends_on:
       - git tag push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -165,11 +165,6 @@ steps:
       source: dist/**/*
       strip_prefix: dist/
       target: test/main
-    when:
-      event: 
-        - push
-      branch:
-        - main
     depends_on:
       - build for test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -120,6 +120,62 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
+name: callisto-ui-test-deploy
+
+platform:
+  os: linux
+  arch: amd64
+
+depends_on:
+  - callisto-ui
+
+trigger:
+  event:
+    - promote
+  target:
+    - test
+
+steps:
+  - name: build for test
+    image: node:16.15.0
+    environment:
+      NPM_AUTH_TOKEN:
+        from_secret: npm_auth_token
+      VITE_KC_URL:
+        from_secret: kc_url_test
+      VITE_KC_REALM:
+        from_secret: kc_realm_test
+      VITE_KC_CLIENTID:
+        from_secret: kc_clientid_test
+      VITE_TIMECARD_API_URL: "https://timecard.test.callisto.homeoffice.gov.uk/"
+      VITE_ACCRUALS_API_URL: "https://accruals.test.callisto.homeoffice.gov.uk/"                        
+    commands:
+      - npm ci
+      - npm run build
+
+  - name: upload to S3
+    image: plugins/s3
+    settings:
+      bucket: ho-callisto-dev
+      region: eu-west-2
+      access_key:
+        from_secret: s3_aws_access_key_id
+      secret_key:
+        from_secret: s3_aws_secret_access_key
+      source: dist/**/*
+      strip_prefix: dist/
+      target: test/main
+    when:
+      event: 
+        - push
+      branch:
+        - main
+    depends_on:
+      - build for test
+
+---
+kind: pipeline
+type: kubernetes
 name: callisto-ui-prod-deploy
 
 platform:
@@ -167,7 +223,6 @@ steps:
       target: main
     depends_on:
       - build for prod
-
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -93,7 +93,7 @@ steps:
       ssh_key:
         from_secret: github_private_key
       commit: true
-      tag: "v$${DRONE_BUILD_NUMBER}"
+      tag: v$${DRONE_BUILD_NUMBER}
       followtags: true
     when:
       event: 

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,17 +85,23 @@ steps:
     depends_on:
       - install dependencies
 
-  # - name: git tag
-  #   image: plugins/git
-  #   commands:      
-  #     - "git tag v$${DRONE_BUILD_NUMBER} && git push origin v$${DRONE_BUILD_NUMBER}"
-  #   when:
-  #     event: 
-  #       - push
-  #     branch:
-  #       - main
-  #   depends_on:
-  #     - build project
+  - name: git tag push
+    image: appleboy/drone-git-push
+    settings:
+      branch: main
+      remote: git@github.com:UKHomeOffice/callisto-ui.git
+      ssh_key:
+        from_secret: github_private_key
+      commit: true
+      tag: "v$${DRONE_BUILD_NUMBER}"
+      followtags: true
+    when:
+      event: 
+        - push
+      # branch:
+      #   - main
+    depends_on:
+      - build project
   
   - name: upload to S3
     image: plugins/s3
@@ -115,7 +121,7 @@ steps:
       branch:
         - main
     depends_on:
-      - build project
+      - git tag push
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -184,57 +184,6 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: callisto-ui-prod-deploy
-
-platform:
-  os: linux
-  arch: amd64
-
-depends_on:
-  - callisto-ui-test-deploy
-
-trigger:
-  event:
-    - promote
-  target:
-    - production
-
-steps:
-  - name: build for prod
-    image: node:16.15.0
-    environment:
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
-      VITE_KC_URL:
-        from_secret: kc_url_prod
-      VITE_KC_REALM:
-        from_secret: kc_realm_prod
-      VITE_KC_CLIENTID:
-        from_secret: kc_clientid_prod
-      VITE_TIMECARD_API_URL: "https://timecard.callisto.homeoffice.gov.uk/"
-      VITE_ACCRUALS_API_URL: "https://accruals.callisto.homeoffice.gov.uk/"                        
-    commands:
-      - npm ci
-      - npm run build
-
-  - name: upload to prod S3
-    image: plugins/s3
-    settings:
-      bucket: ho-callisto
-      region: eu-west-2
-      access_key:
-        from_secret: s3_aws_access_key_id_prod
-      secret_key:
-        from_secret: s3_aws_secret_access_key_prod
-      source: dist/**/*
-      strip_prefix: dist/
-      target: main
-    depends_on:
-      - build for prod
-
----
-kind: pipeline
-type: kubernetes
 name: callisto-ui notifications
 
 trigger:
@@ -246,8 +195,7 @@ trigger:
 
 depends_on:
   - callisto-ui
-  - callisto-ui-test-deploy
-  - callisto-ui-prod-deploy
+  - callisto-ui-test-deploy  
 
 slack: &slack
   image: plugins/slack

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  event:
+    exclude:
+      - promote  
+
 steps:
   - name: fetch
     image: alpine/git

--- a/.drone.yml
+++ b/.drone.yml
@@ -120,6 +120,58 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
+name: callisto-ui-prod-deploy
+
+platform:
+  os: linux
+  arch: amd64
+
+depends_on:
+  - callisto-ui
+
+trigger:
+  event:
+    - promote
+  target:
+    - production
+
+steps:
+  - name: build for prod
+    image: node:16.15.0
+    environment:
+      NPM_AUTH_TOKEN:
+        from_secret: npm_auth_token
+      VITE_KC_URL:
+        from_secret: kc_url_prod
+      VITE_KC_REALM:
+        from_secret: kc_realm_prod
+      VITE_KC_CLIENTID:
+        from_secret: kc_clientid_prod
+      VITE_TIMECARD_API_URL: "https://timecard.callisto.homeoffice.gov.uk/"
+      VITE_ACCRUALS_API_URL: "https://accruals.callisto.homeoffice.gov.uk/"                        
+    commands:
+      - npm ci
+      - npm run build
+
+  - name: upload to prod S3
+    image: plugins/s3
+    settings:
+      bucket: ho-callisto
+      region: eu-west-2
+      access_key:
+        from_secret: s3_aws_access_key_id_prod
+      secret_key:
+        from_secret: s3_aws_secret_access_key_prod
+      source: dist/**/*
+      strip_prefix: dist/
+      target: main
+    depends_on:
+      - build for prod
+
+
+---
+kind: pipeline
+type: kubernetes
 name: build notifications
 
 trigger:

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,6 +85,18 @@ steps:
     depends_on:
       - install dependencies
 
+  - name: git tag
+    image: alpine/git
+    commands:      
+      - "git tag v$${DRONE_BUILD_NUMBER} && git push origin v$${DRONE_BUILD_NUMBER}"
+    when:
+      event: 
+        - push
+      branch:
+        - main
+    depends_on:
+      - build project
+  
   - name: upload to S3
     image: plugins/s3
     settings:
@@ -98,7 +110,8 @@ steps:
       strip_prefix: dist/
       target: dev/main
     when:
-      event: push
+      event: 
+        - push
       branch:
         - main
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -147,8 +147,8 @@ steps:
         from_secret: kc_realm_test
       VITE_KC_CLIENTID:
         from_secret: kc_clientid_test
-      VITE_TIMECARD_API_URL: "https://timecard.test.callisto.homeoffice.gov.uk/"
-      VITE_ACCRUALS_API_URL: "https://accruals.test.callisto.homeoffice.gov.uk/"                        
+      VITE_TIMECARD_API_URL: "https://timecard.test.callisto-notprod.homeoffice.gov.uk/"
+      VITE_ACCRUALS_API_URL: "https://accruals.test.callisto-notprod.homeoffice.gov.uk/"                        
     commands:
       - npm ci
       - npm run build

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,8 @@ platform:
 trigger:
   event:
     exclude:
-      - promote  
+      - promote
+      - tag  
 
 steps:
   - name: fetch

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,17 +85,17 @@ steps:
     depends_on:
       - install dependencies
 
-  - name: git tag
-    image: alpine/git
-    commands:      
-      - "git tag v$${DRONE_BUILD_NUMBER} && git push origin v$${DRONE_BUILD_NUMBER}"
-    # when:
-    #   event: 
-    #     - push
-    #   branch:
-    #     - main
-    depends_on:
-      - build project
+  # - name: git tag
+  #   image: plugins/git
+  #   commands:      
+  #     - "git tag v$${DRONE_BUILD_NUMBER} && git push origin v$${DRONE_BUILD_NUMBER}"
+  #   when:
+  #     event: 
+  #       - push
+  #     branch:
+  #       - main
+  #   depends_on:
+  #     - build project
   
   - name: upload to S3
     image: plugins/s3

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
       - "git fetch origin +refs/heads/main:"
 
   - name: install dependencies
-    image: &node_image # the version we're targeting for productio
+    image: &node_image # the version we're targeting for production
       node:16.15.0
     environment:
       NPM_AUTH_TOKEN:

--- a/.drone.yml
+++ b/.drone.yml
@@ -178,7 +178,7 @@ platform:
   arch: amd64
 
 depends_on:
-  - callisto-ui
+  - callisto-ui-test-deploy
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -193,6 +193,7 @@ trigger:
 
 depends_on:
   - callisto-ui
+  - callisto-ui-dev-deploy
   - callisto-ui-test-deploy  
 
 slack: &slack

--- a/.drone.yml
+++ b/.drone.yml
@@ -222,26 +222,33 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: build notifications
+name: callisto-ui notifications
 
 trigger:
   status:
     - success
     - failure
-  event:
-    - push
+  # event:
+  #   - push
 
 depends_on:
   - callisto-ui
+  - callisto-ui-test-deploy
+  - callisto-ui-prod-deploy
 
-steps:
-  - name: slack
-    image: plugins/slack
+slack: &slack
+  image: plugins/slack
+  settings:
+    webhook:
+      from_secret: SLACK_WEBHOOK_URL
+    channel: callisto-tech-notifications
+    username: Drone
+
+  
+steps:  
+  - name: slack_build
+    <<: *slack
     settings:
-      webhook:
-        from_secret: SLACK_WEBHOOK_URL
-      channel: callisto-tech-notifications
-      username: Drone
       template: |
         {{#success build.status}}
           Build #{{ build.number }} succeeded! :tada:
@@ -253,3 +260,19 @@ steps:
         Branch: <${DRONE_REPO_LINK}/commits/{{ build.branch }}|{{ build.branch }}>
         Author: {{ build.author }}
         <https://sonarcloud.io/dashboard?id=callisto-ui&branch={{ build.branch }}&resolved=false|SonarCloud Analysis Report>
+    when:
+      event: 
+        - push
+
+  - name: slack_deploy
+    <<: *slack
+    settings:
+      template: >
+        {{#success build.status}}
+          :rocket: Successful *{{uppercasefirst build.deployTo}}* deployment for *{{repo.name}} build #{{build.number}}*.          
+        {{else}}
+          :zombie: Problem *{{uppercasefirst build.deployTo}}* deployment failed for <${DRONE_BUILD_LINK}| build #{{build.number}}>.
+        {{/success}}       
+    when:
+      event: 
+        - promote   


### PR DESCRIPTION
These are changes to the UI build pipelines to enable a manual promotion to Test. Manual promotion to Production will be a later PR depending on how this goes. Summary of the main changes are:

- Exclude the Build pipeline (clone, fetch, install, lint, test, sonar & build) from triggering on Promote and Tag events
- Create a new Dev deploy pipeline with a new step to git tag the build using the build number (for now, semver later), then do the upload to S3 step. This new pipeline is only triggered on push to the Main branch e.g. pull request merge. It has a dependency on the Build pipeline succeeding
- Create a new Test deploy pipeline with new steps to: (1) build for Test using the Test environment variables (2) upload to the dev S3 bucket Test folder. This depends on the previous Dev deploy pipeline success.
- Add a new notification for the new Promote step which is only triggered by the Promote event
