### PR TITLE
EAHW-2429: Move tag and upload steps back to build pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -101,8 +101,7 @@ steps:
        - push
       branch:
        - main  
-    depends_on:
-      - install dependencies
+    depends_on:      
       - sonar analysis
   
   - name: upload to S3

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,25 +86,6 @@ steps:
     depends_on:
       - install dependencies
 
----
-kind: pipeline
-type: kubernetes
-name: callisto-ui-dev-deploy
-
-platform:
-  os: linux
-  arch: amd64
-
-depends_on:
-  - callisto-ui
-
-trigger:
-  event:
-    - push
-  branch:
-    - main  
-
-steps:
   - name: git tag push
     image: appleboy/drone-git-push
     settings:
@@ -113,8 +94,16 @@ steps:
       ssh_key:
         from_secret: github_private_key
       commit: true
-      tag: v$${DRONE_BUILD_NUMBER}
-      followtags: true     
+      tag: v${DRONE_BUILD_NUMBER}
+      followtags: true
+    when:
+      event:
+       - push
+      branch:
+       - main  
+    depends_on:
+      - install dependencies
+      - sonar analysis
   
   - name: upload to S3
     image: plugins/s3
@@ -128,6 +117,11 @@ steps:
       source: dist/**/*
       strip_prefix: dist/
       target: dev/main
+    when:
+      event:
+       - push
+      branch:
+       - main  
     depends_on:
       - git tag push
 
@@ -141,7 +135,7 @@ platform:
   arch: amd64
 
 depends_on:
-  - callisto-ui-dev-deploy
+  - callisto-ui
 
 trigger:
   event:
@@ -193,8 +187,7 @@ trigger:
     - failure
 
 depends_on:
-  - callisto-ui
-  - callisto-ui-dev-deploy
+  - callisto-ui  
   - callisto-ui-test-deploy  
 
 slack: &slack


### PR DESCRIPTION
Moving the tag and upload steps back into the build pipeline - to fix the issue where there are no files available to the pipeline to be uploaded. See screenshot below.

Also git tag is not pulling the drone build version through - trying tweaking the syntax.

![calamity-drone](https://user-images.githubusercontent.com/104449079/203828400-0edd5710-5e7e-4387-9e33-0f30484e1bb9.png)