### PR TITLE
EAHW-2434: Incorrect text for clashing shift with no end date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist-ssr
 
 # json-server db
 db.json
+
+#APIs
+start-timecard-api.ps1

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -40,12 +40,8 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
 
     if (timePeriodType === 'Shift') {
-      const endDateText = clash.endTime
-        ? `to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`
-        : '';
-
       text = `You are already assigned to work from 
-      ${formatStartDateTime(clash)} ${endDateText}`;
+      ${formatStartDateTime(clash)} ${getEndTimeText(clash.endTime)}`;
     } else {
       text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${formatLongDate(
         clash.startTime
@@ -83,14 +79,18 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
 
     if (timePeriodType === 'Shift') {
-      return `${formatStartDateTime(clash)} to ${formatTime(
-        clash.endTime
-      )} on ${formatLongDate(clash.endTime)}`;
+      return `${formatStartDateTime(clash)} ${getEndTimeText(clash.endTime)}`;
     }
 
     return `${timePeriodType.toLowerCase()} on ${formatLongDate(
       clash.startTime
     )}`;
+  };
+
+  const getEndTimeText = (endTime) => {
+    return endTime
+      ? `to ${formatTime(endTime)} on ${formatLongDate(endTime)}`
+      : '';
   };
 
   const formatStartDateTime = (clash) => {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.jsx
@@ -40,9 +40,12 @@ const TimeInputErrors = ({ clashingProperty, clashes }) => {
     const timePeriodType = timePeriodTypesMap[clash.timePeriodTypeId];
 
     if (timePeriodType === 'Shift') {
-      text = `You are already assigned to work from ${formatStartDateTime(
-        clash
-      )} to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`;
+      const endDateText = clash.endTime
+        ? `to ${formatTime(clash.endTime)} on ${formatLongDate(clash.endTime)}`
+        : '';
+
+      text = `You are already assigned to work from 
+      ${formatStartDateTime(clash)} ${endDateText}`;
     } else {
       text = `You are already assigned a ${timePeriodType.toLowerCase()} on ${formatLongDate(
         clash.startTime

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -114,6 +114,28 @@ describe('TimeInputErrors', () => {
       );
       expect(clashingShiftError).toBeTruthy();
     });
+
+    it('should only include the clashing shift start time in the error message when there is no clashing shift end time', () => {
+      const shiftClash = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T08:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={clashingProperties.startTime}
+          clashes={shiftClash}
+        />
+      );
+
+      const startTimeClashText =
+        'You are already assigned to work from 08:00 on 3 November 2022';
+
+      expect(screen.getByText(startTimeClashText)).toBeTruthy();
+      expect(screen.queryByText(`${startTimeClashText} to`)).toBeFalsy();
+    });
   });
 
   describe('Multiple time clashes', () => {

--- a/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
+++ b/src/components/timecard/time-input-errors/TimeInputErrors.spec.jsx
@@ -320,6 +320,41 @@ describe('TimeInputErrors', () => {
         '08:00 to 12:00 on 4 November 2022'
       );
     });
+
+    it('should only include the clashing shift start time in the error message when there is no clashing shift end time', () => {
+      const shiftClash = [
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-03T08:00:00.000+00:00',
+          endTime: '2022-11-04T16:00:00.000+00:00',
+        },
+        {
+          timePeriodTypeId: '00000000-0000-0000-0000-000000000001',
+          startTime: '2022-11-04T17:00:00.000+00:00',
+        },
+      ];
+
+      renderWithTimecardContext(
+        <TimeInputErrors
+          clashingProperty={clashingProperties.startTime}
+          clashes={shiftClash}
+        />
+      );
+
+      const clashingTimePeriods = screen
+        .getAllByTestId('test')
+        .map(getNodeText);
+
+      expect(clashingTimePeriods[0]).toEqual(
+        '08:00 on 3 November 2022 to 16:00 on 4 November 2022'
+      );
+
+      const secondTimePeriodClashText = '17:00 on 4 November 2022';
+      expect(clashingTimePeriods[1].trimEnd()).toEqual(
+        secondTimePeriodClashText
+      );
+      expect(screen.queryByText(`${secondTimePeriodClashText} to`)).toBeFalsy();
+    });
   });
 
   describe('Clash finishes on a different day', () => {


### PR DESCRIPTION
- update validation to not attempt to show endtime in error message when there is no end time.
- update gitIgnore to exclude powershell file for running backend.