### PR TITLE
Fix: remove trailing slash

### DIFF
--- a/src/api/services/timecardService.js
+++ b/src/api/services/timecardService.js
@@ -13,7 +13,7 @@ export const getTimecard = async (params) => {
 
 export const getTimeEntries = async (params) => {
   try {
-    return await api.get(baseUrl + 'resources/time-entries/', params);
+    return await api.get(baseUrl + 'resources/time-entries', params);
   } catch (error) {
     throw new Error(serviceName + ' getTimeEntries function threw ' + error);
   }


### PR DESCRIPTION
Remove trailing slash from getTimeEntries endpoint